### PR TITLE
allow to use absolute path for models

### DIFF
--- a/ios/RCTARKit.m
+++ b/ios/RCTARKit.m
@@ -317,8 +317,13 @@
 
 - (void)addModel:(NSDictionary *)property {
     CGFloat scale = [property[@"scale"] floatValue];
-    
-    NSURL *url = [[NSBundle mainBundle] URLForResource:property[@"file"] withExtension:nil];
+    NSString * filePath = property[@"file"];
+    NSURL *url;
+    if([filePath hasPrefix: @"/"]) {
+        url = [NSURL fileURLWithPath: filePath];
+    } else {
+        url = [[NSBundle mainBundle] URLForResource:filePath withExtension:nil];
+    }
     SCNNode *node = [self loadModel:url nodeName:property[@"node"] withAnimation:YES];
     node.scale = SCNVector3Make(scale, scale, scale);
     [self addNodeToScene:node property:property];


### PR DESCRIPTION
this allow to use load models from different locations. E.g. its possible to download a model from the internet.

See this gist for an example implementation: https://gist.github.com/macrozone/e20b9f6ab2bf529331e6019efa08e92f

See also : https://github.com/HippoAR/react-native-arkit/issues/26#issuecomment-328611061


Edit: I published a version with this change on npm:

`npm install --save @panter/react-native-arkit`

or `yarn add @panter/react-native-arkit`