### PR TITLE
clear scene on resume

### DIFF
--- a/ios/RCTARKit.m
+++ b/ios/RCTARKit.m
@@ -79,6 +79,11 @@
 }
 
 - (void)resume {
+    // clear scene
+    for(id key in self.nodes) {
+        id node = [self.nodes objectForKey:key];
+        [node removeFromParentNode];
+    }
     [self.session runWithConfiguration:self.configuration];
 }
 


### PR DESCRIPTION
this removes every node on resume so that its in sync with react when a ARKit-View is mounted.

This also works when hot-reloading is enabled.

published under `@panter/react-native-arkit@0.1.5` 
