### PR TITLE
WIP: add function to capture image from camera without 3d models

### DIFF
--- a/ARKit.js
+++ b/ARKit.js
@@ -127,6 +127,7 @@ const styles = StyleSheet.create({
 
 ARKit.getCameraPosition = ARKitManager.getCameraPosition;
 ARKit.snapshot = ARKitManager.snapshot;
+ARKit.snapshotCamera = ARKitManager.snapshotCamera;
 ARKit.pause = ARKitManager.pause;
 ARKit.resume = ARKitManager.resume;
 ARKit.addBox = parseColorWrapper(ARKitManager.addBox);

--- a/ios/RCTARKit.h
+++ b/ios/RCTARKit.h
@@ -44,6 +44,7 @@
 - (void)pause;
 - (void)resume;
 - (void)snapshot:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject;
+- (void)snapshotCamera:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject;
 
 - (NSDictionary *)readCameraPosition;
 

--- a/ios/RCTARKit.m
+++ b/ios/RCTARKit.m
@@ -166,6 +166,26 @@
     UIImageWriteToSavedPhotosAlbum(image, self, @selector(thisImage:savedInAlbumWithError:ctx:), NULL);
 }
 
+
+- (void)snapshotCamera:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject {
+    
+    // thx https://stackoverflow.com/a/8094038/1463534
+    CVPixelBufferRef pixelBuffer = self.arView.session.currentFrame.capturedImage;
+    CIImage *ciImage = [CIImage imageWithCVPixelBuffer:pixelBuffer];
+    
+    CIContext *temporaryContext = [CIContext contextWithOptions:nil];
+    CGImageRef videoImage = [temporaryContext
+                             createCGImage:ciImage
+                             fromRect:CGRectMake(0, 0,
+                                                 CVPixelBufferGetWidth(pixelBuffer),
+                                                 CVPixelBufferGetHeight(pixelBuffer))];
+    
+    UIImage *image = [UIImage imageWithCGImage:videoImage scale: 1.0 orientation:UIImageOrientationRight];
+    CGImageRelease(videoImage);
+    _resolve = resolve;
+    UIImageWriteToSavedPhotosAlbum(image, self, @selector(thisImage:savedInAlbumWithError:ctx:), NULL);
+}
+
 - (void)thisImage:(UIImage *)image savedInAlbumWithError:(NSError *)error ctx:(void *)ctx {
     if (error) {
     } else {

--- a/ios/RCTARKitManager.h
+++ b/ios/RCTARKitManager.h
@@ -16,6 +16,7 @@
 - (void)resume:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject;
 
 - (void)snapshot:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject;
+- (void)snapshotCamera:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject;
 - (void)getCameraPosition:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject;
 
 - (void)addBox:(NSDictionary *)property;

--- a/ios/RCTARKitManager.m
+++ b/ios/RCTARKitManager.m
@@ -39,6 +39,10 @@ RCT_EXPORT_METHOD(snapshot:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRej
     [[ARKit sharedInstance] snapshot:resolve reject:reject];
 }
 
+RCT_EXPORT_METHOD(snapshotCamera:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {
+    [[ARKit sharedInstance] snapshotCamera:resolve reject:reject];
+}
+
 RCT_EXPORT_METHOD(getCameraPosition:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {
     resolve([[ARKit sharedInstance] readCameraPosition]);
 }


### PR DESCRIPTION
adds a new method snapshotCamera

which stores the camera image without the 3d model.

TODO: 

- [ ] fix all orientations


further improvements:

- [ ] snapshot and snapshotCamera should allow to specify where the image should be stored and should return the path in the resolve-function