### PR TITLE
expose hitTestPlanes function

### DIFF
--- a/ARKit.js
+++ b/ARKit.js
@@ -126,6 +126,8 @@ const styles = StyleSheet.create({
 });
 
 ARKit.getCameraPosition = ARKitManager.getCameraPosition;
+ARKit.ARHitTestResultType = ARKitManager.ARHitTestResultType;
+ARKit.hitTestPlanes = ARKitManager.hitTestPlanes;
 ARKit.snapshot = ARKitManager.snapshot;
 ARKit.pause = ARKitManager.pause;
 ARKit.resume = ARKitManager.resume;

--- a/ios/RCTARKit.h
+++ b/ios/RCTARKit.h
@@ -43,6 +43,7 @@
 #pragma mark - Public Method
 - (void)pause;
 - (void)resume;
+- (void)hitTestPlane:(CGPoint)tapPoint types:(ARHitTestResultType)types resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject;
 - (void)snapshot:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject;
 
 - (NSDictionary *)readCameraPosition;

--- a/ios/RCTARKit.m
+++ b/ios/RCTARKit.m
@@ -160,6 +160,12 @@
 
 #pragma mark - Methods
 
+- (void)hitTestPlane:(const CGPoint)tapPoint types:(ARHitTestResultType)types resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject {
+    
+    resolve([self getPlaneHitResult:tapPoint types:types]);
+}
+
+
 - (void)snapshot:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject {
     UIImage *image = [self.arView snapshot];
     _resolve = resolve;

--- a/ios/RCTARKitManager.h
+++ b/ios/RCTARKitManager.h
@@ -14,7 +14,7 @@
 
 - (void)pause:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject;
 - (void)resume:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject;
-
+- (void)hitTestPlanes: (NSDictionary *)pointDict types:(NSUInteger)types resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject;
 - (void)snapshot:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject;
 - (void)getCameraPosition:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject;
 

--- a/ios/RCTARKitManager.m
+++ b/ios/RCTARKitManager.m
@@ -17,6 +17,18 @@ RCT_EXPORT_MODULE()
     return [ARKit sharedInstance];
 }
 
+- (NSDictionary *)constantsToExport
+{
+    return @{
+             @"ARHitTestResultType": @{
+                     @"FeaturePoint": @(ARHitTestResultTypeFeaturePoint),
+                     @"EstimatedHorizontalPlane": @(ARHitTestResultTypeEstimatedHorizontalPlane),
+                     @"ExistingPlane": @(ARHitTestResultTypeExistingPlane),
+                     @"ExistingPlaneUsingExtent": @(ARHitTestResultTypeExistingPlaneUsingExtent)
+                     },
+             };
+}
+
 RCT_EXPORT_VIEW_PROPERTY(debug, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(planeDetection, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(lightEstimation, BOOL)
@@ -34,6 +46,19 @@ RCT_EXPORT_METHOD(resume:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejec
     [[RCTARKit sharedInstance] resume];
     resolve(@{});
 }
+
+
+RCT_EXPORT_METHOD(
+  hitTestPlanes: (NSDictionary *)pointDict
+  types:(NSUInteger)types
+  resolve:(RCTPromiseResolveBlock)resolve
+  reject:(RCTPromiseRejectBlock)reject
+  ) {
+    CGPoint point = CGPointMake(  [pointDict[@"x"] floatValue], [pointDict[@"y"] floatValue] );
+    [[ARKit sharedInstance] hitTestPlane:point types:types resolve:resolve reject:reject];
+}
+
+
 
 RCT_EXPORT_METHOD(snapshot:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {
     [[ARKit sharedInstance] snapshot:resolve reject:reject];


### PR DESCRIPTION
exposes a new static function to do hit-detection on planes. It's a more low-level implementation of https://github.com/HippoAR/react-native-arkit/pull/27

Usage example:

```
// you want to do hit-detection in js, e.g. find the point in the AR-space that is in the center of the current camera-view:

import { ARKit } from 'react-native-arkit'
import { Dimensions } from 'react-native'

const getScreenCenter = () => ({
  x: Dimensions.get('window').width / 2,
  y: Dimensions.get('window').height / 2,
})

// somewhere in a callback, e.g. on button onPress:

ARKit.hitTestPlanes(
  getScreenCenter(), ARKit.ARHitTestResultType.ExistingPlane
).then(
  ({ results }) => {
    // results is array of hit-results
    console.log(results)
  }
)
```



released under `@panter/react-native-arkit@0.1.7`