### PR TITLE
WIP: callback on frame / camera change

### DIFF
--- a/ARKit.js
+++ b/ARKit.js
@@ -166,6 +166,7 @@ ARKit.propTypes = {
   planeDetection: PropTypes.bool,
   lightEstimation: PropTypes.bool,
   onPlaneDetected: PropTypes.func,
+  onFrameUpdate: PropTypes.func,
   onPlaneUpdate: PropTypes.func,
   onTrackingState: PropTypes.func,
   onTapOnPlaneUsingExtent: PropTypes.func,

--- a/ios/RCTARKit.h
+++ b/ios/RCTARKit.h
@@ -35,6 +35,7 @@
 @property (nonatomic, assign) BOOL lightEstimation;
 
 @property (nonatomic, copy) RCTBubblingEventBlock onPlaneDetected;
+@property (nonatomic, copy) RCTBubblingEventBlock onFrameUpdate;
 @property (nonatomic, copy) RCTBubblingEventBlock onPlaneUpdate;
 @property (nonatomic, copy) RCTBubblingEventBlock onTrackingState;
 @property (nonatomic, copy) RCTBubblingEventBlock onTapOnPlaneUsingExtent;

--- a/ios/RCTARKit.m
+++ b/ios/RCTARKit.m
@@ -378,6 +378,11 @@ static NSDictionary * getPlaneHitResult(NSMutableArray *resultsMapped, const CGP
             [sessionDelegate session:session didUpdateFrame:frame];
         }
     }
+    if (self.onFrameUpdate) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            self.onFrameUpdate(@{});
+        });
+    }
 }
 
 - (void)session:(ARSession *)session cameraDidChangeTrackingState:(ARCamera *)camera {

--- a/ios/RCTARKitManager.m
+++ b/ios/RCTARKitManager.m
@@ -37,6 +37,7 @@ RCT_EXPORT_VIEW_PROPERTY(lightEstimation, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(onPlaneDetected, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onPlaneUpdate, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onTrackingState, RCTBubblingEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onFrameUpdate, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onEvent, RCTBubblingEventBlock)
 
 RCT_EXPORT_METHOD(pause:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {


### PR DESCRIPTION
goal is to have a callback that fires whenever the camera moves. E.g. this can be used if you want to draw something on the 3d scene while the device is beeing moved.

I used didUpdateFrame for that, but i am not sure if this affects performance or energy consumption negativly.