### PR TITLE
WIP: add ARGroup

### DIFF
--- a/components/ARGroup.js
+++ b/components/ARGroup.js
@@ -1,0 +1,10 @@
+import { View } from 'react-native';
+import React, { Component } from 'react';
+
+const ARGroup = class extends Component {
+  render() {
+    return <View>{this.props.children}</View>;
+  }
+};
+
+module.exports = ARGroup;

--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ import ARCapsule from './components/ARCapsule';
 import ARPlane from './components/ARPlane';
 import ARText from './components/ARText';
 import ARModel from './components/ARModel';
+import ARGroup from './components/ARGroup';
 
 ARKit.Box = ARBox;
 ARKit.Sphere = ARSphere;
@@ -31,6 +32,7 @@ ARKit.Capsule = ARCapsule;
 ARKit.Plane = ARPlane;
 ARKit.Text = ARText;
 ARKit.Model = ARModel;
+ARKit.Group = ARGroup;
 
 module.exports = {
   ARKit,
@@ -46,4 +48,5 @@ module.exports = {
   ARPlane,
   ARText,
   ARModel,
+  ARGroup,
 };


### PR DESCRIPTION
it solves https://github.com/HippoAR/react-native-arkit/issues/45

its a basic implementation without any position or rotation support. It's just that you can organize multiple components in one component.

This would also be solved through React 16's support for fragments (Returning an array of elements inside render. But react 16 is not yet available for react-native.

I needed some kind of dummy wrapper component, but the only solution i found was to abuse a `<View>` for that. I don't know if this has negative impact though.