### PR TITLE
fix absolute paths

### DIFF
--- a/ios/RCTARKitIO.m
+++ b/ios/RCTARKitIO.m
@@ -34,7 +34,12 @@
 
 - (SCNNode *)loadModel:(NSString *)path nodeName:(NSString *)nodeName withAnimation:(BOOL)withAnimation {
     NSURL *url = [self urlFromPath:path];
-    SCNScene *scene = [SCNScene sceneWithURL:url options:nil error:nil];
+    NSError* error;
+    
+    SCNScene *scene = [SCNScene sceneWithURL:url options:nil error:&error];
+    if(error) {
+        NSLog(@"%@",[error localizedDescription]);
+    }
     
     SCNNode *node;
     if (nodeName) {
@@ -113,9 +118,12 @@
 
 
 - (NSURL *)urlFromPath:(NSString *)path {
+    
     NSURL *url;
     
-    if ([path rangeOfString:@"scnassets"].location == NSNotFound) {
+    if([path hasPrefix: @"/"]) {
+        url = [NSURL fileURLWithPath: path];
+    } else if ([path rangeOfString:@"scnassets"].location == NSNotFound) {
         NSString *assetPath = [self getAppLibraryCachesPathWithSubDirectory:nil];
         NSString *modelPath = [NSString stringWithFormat:@"file://%@", [assetPath stringByAppendingPathComponent:path]];
         url = [NSURL URLWithString:[modelPath stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]]];


### PR DESCRIPTION
there is a regression concering loading models from absolute paths.

If the string passed to the file property of a model component starts with /, its considered an absolute path. It will get prefixed with "file"-protocol by using ` [NSURL fileURLWithPath: path];`

I would try to rethink the current implementation there and offload the responsibility for file loading to the js-part, as this will make a future implementation in android easier.

as described in this [gist](https://gist.github.com/macrozone/e20b9f6ab2bf529331e6019efa08e92f) you can do downloading and unzipping files perfectly in the javascript code.

maybe we can do the logic more explicit, by introducing different properties to specify different storage location (e.g. `file` for absolute file path in cache or documents or any storage (sd card, etc.) and `asset` for a bundled file) .
