### PR TITLE
Use the React-Native way to process color

### DIFF
--- a/components/lib/parseColor.js
+++ b/components/lib/parseColor.js
@@ -1,12 +1,4 @@
-import Color from 'color';
-
-export const normalizeColor = colorRaw => {
-  const color = new Color(colorRaw);
-  return {
-    alpha: 1,
-    ...color.unitObject(),
-  };
-};
+import { processColor } from 'react-native';
 
 export function parseColorInProps(props) {
   if (props && props.material && props.material.color) {
@@ -14,7 +6,7 @@ export function parseColorInProps(props) {
       ...props,
       material: {
         ...props.material,
-        color: normalizeColor(props.material.color),
+        color: processColor(props.material.color),
       },
     };
   }

--- a/ios/RCTARKit.xcodeproj/project.pbxproj
+++ b/ios/RCTARKit.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		10062C831F127572009AE974 /* RCTARKitManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 10062C821F127572009AE974 /* RCTARKitManager.m */; };
 		1021FE1C1F3EDB98000E7339 /* ARModelManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 1021FE181F3EDB90000E7339 /* ARModelManager.m */; };
 		1021FE1D1F3EDB9B000E7339 /* ARTextManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 1021FE191F3EDB90000E7339 /* ARTextManager.m */; };
+		105F124E1F7C0719006D4BA3 /* RCTConvert+ARKit.m in Sources */ = {isa = PBXBuildFile; fileRef = 105F124D1F7C0718006D4BA3 /* RCTConvert+ARKit.m */; };
 		106999E51F3EC30100032829 /* ARBoxManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 106999E41F3EC2FB00032829 /* ARBoxManager.m */; };
 		106DA3161F443CF300B93D36 /* ARPyramidManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 106DA3151F443CF300B93D36 /* ARPyramidManager.m */; };
 		106DA3191F443D1D00B93D36 /* ARSphereManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 106DA3181F443D1D00B93D36 /* ARSphereManager.m */; };
@@ -48,6 +49,8 @@
 		1021FE191F3EDB90000E7339 /* ARTextManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ARTextManager.m; sourceTree = "<group>"; };
 		1021FE1A1F3EDB90000E7339 /* ARTextManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ARTextManager.h; sourceTree = "<group>"; };
 		1021FE1B1F3EDB90000E7339 /* ARModelManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ARModelManager.h; sourceTree = "<group>"; };
+		105F124C1F7C0718006D4BA3 /* RCTConvert+ARKit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RCTConvert+ARKit.h"; sourceTree = "<group>"; };
+		105F124D1F7C0718006D4BA3 /* RCTConvert+ARKit.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "RCTConvert+ARKit.m"; sourceTree = "<group>"; };
 		106999E31F3EC2FB00032829 /* ARBoxManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ARBoxManager.h; sourceTree = "<group>"; };
 		106999E41F3EC2FB00032829 /* ARBoxManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ARBoxManager.m; sourceTree = "<group>"; };
 		106DA3141F443CF300B93D36 /* ARPyramidManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ARPyramidManager.h; sourceTree = "<group>"; };
@@ -147,6 +150,8 @@
 				10FEF6121F774C9000EC21AE /* RCTARKitNodes.m */,
 				10062C811F127566009AE974 /* RCTARKitManager.h */,
 				10062C821F127572009AE974 /* RCTARKitManager.m */,
+				105F124C1F7C0718006D4BA3 /* RCTConvert+ARKit.h */,
+				105F124D1F7C0718006D4BA3 /* RCTConvert+ARKit.m */,
 				134814211AA4EA7D00B7C361 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -219,6 +224,7 @@
 				106DA31F1F443D3900B93D36 /* ARConeManager.m in Sources */,
 				1021FE1C1F3EDB98000E7339 /* ARModelManager.m in Sources */,
 				1021FE1D1F3EDB9B000E7339 /* ARTextManager.m in Sources */,
+				105F124E1F7C0719006D4BA3 /* RCTConvert+ARKit.m in Sources */,
 				106DA31C1F443D2A00B93D36 /* ARCylinderManager.m in Sources */,
 				106DA3221F443D8300B93D36 /* ARTubeManager.m in Sources */,
 				B3E7B58A1CC2AC0600A0062D /* RCTARKit.m in Sources */,

--- a/ios/RCTARKitGeos.m
+++ b/ios/RCTARKitGeos.m
@@ -7,6 +7,7 @@
 //
 
 #import "RCTARKitGeos.h"
+#import "RCTConvert+ARKit.h"
 
 @implementation RCTARKitGeos
 
@@ -223,31 +224,7 @@
 - (void)addImage:(NSDictionary *)property {}
 
 - (SCNMaterial *)materialFromProperty:(NSDictionary *)property {
-    SCNMaterial *scnMaterial = [SCNMaterial new];
-    
-    NSDictionary* material = property[@"material"];
-    
-    if (material[@"color"]) {
-        CGFloat r = [material[@"color"][@"r"] floatValue];
-        CGFloat g = [material[@"color"][@"g"] floatValue];
-        CGFloat b = [material[@"color"][@"b"] floatValue];
-        CGFloat alpha = [material[@"color"][@"alpha"] floatValue];
-        UIColor *color = [[UIColor alloc] initWithRed:r green:g blue:b alpha:alpha];
-        scnMaterial.diffuse.contents = color;
-    } else {
-        scnMaterial.diffuse.contents = [UIColor whiteColor];
-    }
-    
-    if (material[@"metalness"]) {
-        scnMaterial.lightingModelName = SCNLightingModelPhysicallyBased;
-        scnMaterial.metalness.contents = @([material[@"metalness"] floatValue]);
-    }
-    if (material[@"roughness"]) {
-        scnMaterial.lightingModelName = SCNLightingModelPhysicallyBased;
-        scnMaterial.roughness.contents = @([material[@"roughness"] floatValue]);
-    }
-    
-    return scnMaterial;
+    return [RCTConvert SCNMaterial:property[@"material"]];
 }
 
 @end

--- a/ios/RCTConvert+ARKit.h
+++ b/ios/RCTConvert+ARKit.h
@@ -1,0 +1,18 @@
+//
+//  RCTConvert+ARKit.h
+//  RCTARKit
+//
+//  Created by Zehao Li on 9/28/17.
+//  Copyright © 2017 HippoAR. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <SceneKit/SceneKit.h>
+#import <React/RCTConvert.h>
+
+@interface RCTConvert (ARKit)
+
++ (SCNMaterial *)SCNMaterial:(id)json;
+
+@end
+

--- a/ios/RCTConvert+ARKit.m
+++ b/ios/RCTConvert+ARKit.m
@@ -1,0 +1,33 @@
+//
+//  RCTConvert+ARKit.m
+//  RCTARKit
+//
+//  Created by Zehao Li on 9/28/17.
+//  Copyright © 2017 HippoAR. All rights reserved.
+//
+
+#import "RCTConvert+ARKit.h"
+
+@implementation RCTConvert (ARKit)
+
++ (SCNMaterial *)SCNMaterial:(id)json {
+    SCNMaterial *material = [SCNMaterial new];
+    if (json[@"color"]) {
+        material.diffuse.contents = [self UIColor:json[@"color"]];
+    } else {
+        material.diffuse.contents = [UIColor blackColor];
+    }
+    
+    if (json[@"metalness"]) {
+        material.lightingModelName = SCNLightingModelPhysicallyBased;
+        material.metalness.contents = @([json[@"metalness"] floatValue]);
+    }
+    if (json[@"roughness"]) {
+        material.lightingModelName = SCNLightingModelPhysicallyBased;
+        material.roughness.contents = @([json[@"roughness"] floatValue]);
+    }
+    
+    return material;
+}
+
+@end


### PR DESCRIPTION
React Native handles colors as follows:

1. A `processColor` method will transform a color string (`'#FFF'`, `'#ffffff'`, etc) or a color name (`'red'`, `'blue'`, ...) to a hex number, which equals `a * 256^4 + r * 256 * ^3 + g * 256 + b`;

2. Native codes will receive this number as a `NSNumber` and use `[RCTConvert UIColor:(id)json]` to convert it to `UIColor`.

This PR modify the `parseColor` method in order to conform to RN's way. It also defines `[RCTConvert SCNMaterial]` method to handle color, metalness, and roughness together.