### PR TITLE
use auto type conversion for material

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ AppRegistry.registerComponent('ReactNativeARKit', () => ReactNativeARKit);
 |---|---|
 | `pos` | `{ x, y, z }` |
 | `shape` | `{ width, height, length, chamfer }` |
-| `material` | `{ color, metalness, roughness }` |
+| `material` | `{ diffuse, metalness, roughness }` |
 
 #### [`<ARKit.Sphere />`](https://developer.apple.com/documentation/scenekit/scnsphere)
 
@@ -161,7 +161,7 @@ AppRegistry.registerComponent('ReactNativeARKit', () => ReactNativeARKit);
 |---|---|
 | `pos` | `{ x, y, z }` |
 | `shape` | `{ radius }` |
-| `material` | `{ color, metalness, roughness }` |
+| `material` | `{ diffuse, metalness, roughness }` |
 
 #### [`<ARKit.Cylinder />`](https://developer.apple.com/documentation/scenekit/scncylinder)
 
@@ -171,7 +171,7 @@ AppRegistry.registerComponent('ReactNativeARKit', () => ReactNativeARKit);
 |---|---|
 | `pos` | `{ x, y, z }` |
 | `shape` | `{ radius, height }` |
-| `material` | `{ color, metalness, roughness }` |
+| `material` | `{ diffuse, metalness, roughness }` |
 
 #### [`<ARKit.Cone />`](https://developer.apple.com/documentation/scenekit/scncone)
 
@@ -181,7 +181,7 @@ AppRegistry.registerComponent('ReactNativeARKit', () => ReactNativeARKit);
 |---|---|
 | `pos` | `{ x, y, z }` |
 | `shape` | `{ topR, bottomR, height }` |
-| `material` | `{ color, metalness, roughness }` |
+| `material` | `{ diffuse, metalness, roughness }` |
 
 #### [`<ARKit.Pyramid />`](https://developer.apple.com/documentation/scenekit/scnpyramid)
 
@@ -191,7 +191,7 @@ AppRegistry.registerComponent('ReactNativeARKit', () => ReactNativeARKit);
 |---|---|
 | `pos` | `{ x, y, z }` |
 | `shape` | `{ width, height, length }` |
-| `material` | `{ color, metalness, roughness }` |
+| `material` | `{ diffuse, metalness, roughness }` |
 
 #### [`<ARKit.Tube />`](https://developer.apple.com/documentation/scenekit/scntube)
 
@@ -201,7 +201,7 @@ AppRegistry.registerComponent('ReactNativeARKit', () => ReactNativeARKit);
 |---|---|
 | `pos` | `{ x, y, z }` |
 | `shape` | `{ innerR, outerR, height }` |
-| `material` | `{ color, metalness, roughness }` |
+| `material` | `{ diffuse, metalness, roughness }` |
 
 #### [`<ARKit.Torus />`](https://developer.apple.com/documentation/scenekit/scntorus)
 
@@ -211,7 +211,7 @@ AppRegistry.registerComponent('ReactNativeARKit', () => ReactNativeARKit);
 |---|---|
 | `pos` | `{ x, y, z }` |
 | `shape` | `{ ringR, pipeR }` |
-| `material` | `{ color, metalness, roughness }` |
+| `material` | `{ diffuse, metalness, roughness }` |
 
 #### [`<ARKit.Capsule />`](https://developer.apple.com/documentation/scenekit/scncapsule)
 
@@ -221,7 +221,7 @@ AppRegistry.registerComponent('ReactNativeARKit', () => ReactNativeARKit);
 |---|---|
 | `pos` | `{ x, y, z }` |
 | `shape` | `{ capR, height }` |
-| `material` | `{ color, metalness, roughness }` |
+| `material` | `{ diffuse, metalness, roughness }` |
 
 #### [`<ARKit.Plane />`](https://developer.apple.com/documentation/scenekit/scnplane)
 
@@ -231,7 +231,7 @@ AppRegistry.registerComponent('ReactNativeARKit', () => ReactNativeARKit);
 |---|---|
 | `pos` | `{ x, y, z }` |
 | `shape` | `{ width, length }` |
-| `material` | `{ color, metalness, roughness }` |
+| `material` | `{ diffuse, metalness, roughness }` |
 
 #### [`<ARKit.Text />`](https://developer.apple.com/documentation/scenekit/scntext)
 
@@ -242,7 +242,7 @@ AppRegistry.registerComponent('ReactNativeARKit', () => ReactNativeARKit);
 | `text` | `String` |
 | `pos` | `{ x, y, z, angle }` |
 | `font` | `{ name, size, depth, chamfer }` |
-| `material` | `{ color, metalness, roughness }` |
+| `material` | `{ diffuse, metalness, roughness }` |
 
 
 #### `<ARKit.Model />`

--- a/components/lib/createArComponent.js
+++ b/components/lib/createArComponent.js
@@ -1,7 +1,7 @@
 import { Component } from 'react';
 import PropTypes from 'prop-types';
 
-import { parseColorInProps } from './parseColor';
+import { processColorInMaterial } from './parseColor';
 import generateId from './generateId';
 
 export default (Manager, propTypes = {}) => {
@@ -10,17 +10,23 @@ export default (Manager, propTypes = {}) => {
 
     componentWillMount() {
       this.identifier = this.props.id || generateId();
-      Manager.mount({
-        id: this.identifier,
-        ...parseColorInProps(this.props),
-      });
+      Manager.mount(
+        {
+          id: this.identifier,
+          ...this.props,
+        },
+        processColorInMaterial(this.props.material),
+      );
     }
 
     componentWillUpdate(props) {
-      Manager.mount({
-        id: this.identifier,
-        ...parseColorInProps(props),
-      });
+      Manager.mount(
+        {
+          id: this.identifier,
+          ...props,
+        },
+        processColorInMaterial(this.props.material),
+      );
     }
 
     componentWillUnmount() {
@@ -58,7 +64,7 @@ export default (Manager, propTypes = {}) => {
     }),
 
     material: PropTypes.shape({
-      color: PropTypes.string,
+      diffuse: PropTypes.string,
       metalness: PropTypes.number,
       roughness: PropTypes.number,
     }),

--- a/components/lib/parseColor.js
+++ b/components/lib/parseColor.js
@@ -1,14 +1,16 @@
 import { processColor } from 'react-native';
 
-export function parseColorInProps(props) {
-  if (props && props.material && props.material.color) {
-    return {
-      ...props,
-      material: {
-        ...props.material,
-        color: processColor(props.material.color),
-      },
-    };
+export function processColorInMaterial(material) {
+  if (!material) {
+    return material;
   }
-  return props;
+
+  if (!material.diffuse && !material.color) {
+    return material;
+  }
+
+  return {
+    ...material,
+    diffuse: processColor(material.diffuse || material.color),
+  };
 }

--- a/ios/RCTARKitGeos.h
+++ b/ios/RCTARKitGeos.h
@@ -19,16 +19,16 @@
 + (instancetype)sharedInstance;
 
 #pragma mark - Add a model or a geometry
-- (void)addBox:(NSDictionary *)property;
-- (void)addSphere:(NSDictionary *)property;
-- (void)addCylinder:(NSDictionary *)property;
-- (void)addCone:(NSDictionary *)property;
-- (void)addPyramid:(NSDictionary *)property;
-- (void)addTube:(NSDictionary *)property;
-- (void)addTorus:(NSDictionary *)property;
-- (void)addCapsule:(NSDictionary *)property;
-- (void)addPlane:(NSDictionary *)property;
-- (void)addText:(NSDictionary *)property;
+- (void)addBox:(NSDictionary *)property material:(SCNMaterial *)material;
+- (void)addSphere:(NSDictionary *)property material:(SCNMaterial *)material;
+- (void)addCylinder:(NSDictionary *)property material:(SCNMaterial *)material;
+- (void)addCone:(NSDictionary *)property material:(SCNMaterial *)material;
+- (void)addPyramid:(NSDictionary *)property material:(SCNMaterial *)material;
+- (void)addTube:(NSDictionary *)property material:(SCNMaterial *)material;
+- (void)addTorus:(NSDictionary *)property material:(SCNMaterial *)material;
+- (void)addCapsule:(NSDictionary *)property material:(SCNMaterial *)material;
+- (void)addPlane:(NSDictionary *)property material:(SCNMaterial *)material;
+- (void)addText:(NSDictionary *)property material:(SCNMaterial *)material;
 - (void)addModel:(NSDictionary *)property;
 - (void)addImage:(NSDictionary *)property;
 

--- a/ios/RCTARKitGeos.m
+++ b/ios/RCTARKitGeos.m
@@ -35,7 +35,7 @@
 
 #pragma mark - add a model or a geometry
 
-- (void)addBox:(NSDictionary *)property {
+- (void)addBox:(NSDictionary *)property material:(SCNMaterial *)material {
     NSDictionary* shape = property[@"shape"];
     CGFloat width = [shape[@"width"] floatValue];
     CGFloat height = [shape[@"height"] floatValue];
@@ -43,113 +43,104 @@
     CGFloat chamfer = [shape[@"chamfer"] floatValue];
     SCNBox *geometry = [SCNBox boxWithWidth:width height:height length:length chamferRadius:chamfer];
     
-    SCNMaterial *material = [self materialFromProperty:property];
     geometry.materials = @[material, material, material, material, material, material];
     
     SCNNode *node = [SCNNode nodeWithGeometry:geometry];
     [self.nodeManager addNodeToScene:node property:property];
 }
 
-- (void)addSphere:(NSDictionary *)property {
+- (void)addSphere:(NSDictionary *)property material:(SCNMaterial *)material {
     NSDictionary* shape = property[@"shape"];
     CGFloat radius = [shape[@"radius"] floatValue];
     SCNSphere *geometry = [SCNSphere sphereWithRadius:radius];
     
-    SCNMaterial *material = [self materialFromProperty:property];
     geometry.materials = @[material];
     
     SCNNode *node = [SCNNode nodeWithGeometry:geometry];
     [self.nodeManager addNodeToScene:node property:property];
 }
 
-- (void)addCylinder:(NSDictionary *)property {
+- (void)addCylinder:(NSDictionary *)property material:(SCNMaterial *)material {
     NSDictionary* shape = property[@"shape"];
     CGFloat radius = [shape[@"radius"] floatValue];
     CGFloat height = [shape[@"height"] floatValue];
     SCNCylinder *geometry = [SCNCylinder cylinderWithRadius:radius height:height];
     
-    SCNMaterial *material = [self materialFromProperty:property];
     geometry.materials = @[material, material, material];
     
     SCNNode *node = [SCNNode nodeWithGeometry:geometry];
     [self.nodeManager addNodeToScene:node property:property];
 }
 
-- (void)addCone:(NSDictionary *)property {
+- (void)addCone:(NSDictionary *)property material:(SCNMaterial *)material {
     NSDictionary* shape = property[@"shape"];
     CGFloat topR = [shape[@"topR"] floatValue];
     CGFloat bottomR = [shape[@"bottomR"] floatValue];
     CGFloat height = [shape[@"height"] floatValue];
     SCNCone *geometry = [SCNCone coneWithTopRadius:topR bottomRadius:bottomR height:height];
     
-    SCNMaterial *material = [self materialFromProperty:property];
     geometry.materials = @[material, material];
     
     SCNNode *node = [SCNNode nodeWithGeometry:geometry];
     [self.nodeManager addNodeToScene:node property:property];
 }
 
-- (void)addPyramid:(NSDictionary *)property {
+- (void)addPyramid:(NSDictionary *)property material:(SCNMaterial *)material {
     NSDictionary* shape = property[@"shape"];
     CGFloat width = [shape[@"width"] floatValue];
     CGFloat length = [shape[@"length"] floatValue];
     CGFloat height = [shape[@"height"] floatValue];
     SCNPyramid *geometry = [SCNPyramid pyramidWithWidth:width height:height length:length];
     
-    SCNMaterial *material = [self materialFromProperty:property];
     geometry.materials = @[material, material, material, material, material];
     
     SCNNode *node = [SCNNode nodeWithGeometry:geometry];
     [self.nodeManager addNodeToScene:node property:property];
 }
 
-- (void)addTube:(NSDictionary *)property {
+- (void)addTube:(NSDictionary *)property material:(SCNMaterial *)material {
     NSDictionary* shape = property[@"shape"];
     CGFloat innerR = [shape[@"innerR"] floatValue];
     CGFloat outerR = [shape[@"outerR"] floatValue];
     CGFloat height = [shape[@"height"] floatValue];
     SCNTube *geometry = [SCNTube tubeWithInnerRadius:innerR outerRadius:outerR height:height];
     
-    SCNMaterial *material = [self materialFromProperty:property];
     geometry.materials = @[material, material, material, material];
     
     SCNNode *node = [SCNNode nodeWithGeometry:geometry];
     [self.nodeManager addNodeToScene:node property:property];
 }
 
-- (void)addTorus:(NSDictionary *)property {
+- (void)addTorus:(NSDictionary *)property material:(SCNMaterial *)material {
     NSDictionary* shape = property[@"shape"];
     CGFloat ringR = [shape[@"ringR"] floatValue];
     CGFloat pipeR = [shape[@"pipeR"] floatValue];
     SCNTorus *geometry = [SCNTorus torusWithRingRadius:ringR pipeRadius:pipeR];
     
-    SCNMaterial *material = [self materialFromProperty:property];
     geometry.materials = @[material];
     
     SCNNode *node = [SCNNode nodeWithGeometry:geometry];
     [self.nodeManager addNodeToScene:node property:property];
 }
 
-- (void)addCapsule:(NSDictionary *)property {
+- (void)addCapsule:(NSDictionary *)property material:(SCNMaterial *)material {
     NSDictionary* shape = property[@"shape"];
     CGFloat capR = [shape[@"capR"] floatValue];
     CGFloat height = [shape[@"height"] floatValue];
     SCNCapsule *geometry = [SCNCapsule capsuleWithCapRadius:capR height:height];
     
-    SCNMaterial *material = [self materialFromProperty:property];
     geometry.materials = @[material];
     
     SCNNode *node = [SCNNode nodeWithGeometry:geometry];
     [self.nodeManager addNodeToScene:node property:property];
 }
 
-- (void)addPlane:(NSDictionary *)property {
+- (void)addPlane:(NSDictionary *)property material:(SCNMaterial *)material {
     NSDictionary* shape = property[@"shape"];
     CGFloat width = [shape[@"width"] floatValue];
     CGFloat height = [shape[@"height"] floatValue];
     SCNPlane *geometry = [SCNPlane planeWithWidth:width height:height];
     
-    SCNMaterial *material = [self materialFromProperty:property];
     material.doubleSided = YES;
     geometry.materials = @[material];
     
@@ -158,7 +149,7 @@
 }
 
 
-- (void)addText:(NSDictionary *)property {
+- (void)addText:(NSDictionary *)property material:(SCNMaterial *)material {
     
     // init SCNText
     NSString *text = [NSString stringWithFormat:@"%@", property[@"text"]];
@@ -191,9 +182,8 @@
     scnText.chamferRadius = chamfer / size;
     
     // material
-    SCNMaterial *face = [self materialFromProperty:property];
-    SCNMaterial *border = [self materialFromProperty:property];
-    scnText.materials = @[face, face, border, border, border];
+//    scnText.materials = @[face, face, border, border, border];
+    scnText.materials = @[material, material, material, material, material];
     
     // init SCNNode
     SCNNode *textNode = [SCNNode nodeWithGeometry:scnText];
@@ -222,9 +212,5 @@
 }
 
 - (void)addImage:(NSDictionary *)property {}
-
-- (SCNMaterial *)materialFromProperty:(NSDictionary *)property {
-    return [RCTConvert SCNMaterial:property[@"material"]];
-}
 
 @end

--- a/ios/RCTConvert+ARKit.m
+++ b/ios/RCTConvert+ARKit.m
@@ -12,8 +12,8 @@
 
 + (SCNMaterial *)SCNMaterial:(id)json {
     SCNMaterial *material = [SCNMaterial new];
-    if (json[@"color"]) {
-        material.diffuse.contents = [self UIColor:json[@"color"]];
+    if (json[@"diffuse"]) {
+        material.diffuse.contents = [self UIColor:json[@"diffuse"]];
     } else {
         material.diffuse.contents = [UIColor blackColor];
     }

--- a/ios/components/ARBoxManager.m
+++ b/ios/components/ARBoxManager.m
@@ -7,7 +7,6 @@
 //
 
 #import "ARBoxManager.h"
-#import "RCTARKit.h"
 #import "RCTARKitGeos.h"
 #import "RCTARKitNodes.h"
 
@@ -15,8 +14,8 @@
 
 RCT_EXPORT_MODULE()
 
-RCT_EXPORT_METHOD(mount:(NSDictionary *)property) {
-    [[RCTARKitGeos sharedInstance] addBox:property];
+RCT_EXPORT_METHOD(mount:(NSDictionary *)property material:(SCNMaterial *)material) {
+    [[RCTARKitGeos sharedInstance] addBox:property material:material];
 }
 
 RCT_EXPORT_METHOD(unmount:(NSString *)identifier) {

--- a/ios/components/ARCapsuleManager.m
+++ b/ios/components/ARCapsuleManager.m
@@ -7,7 +7,6 @@
 //
 
 #import "ARCapsuleManager.h"
-#import "RCTARKit.h"
 #import "RCTARKitGeos.h"
 #import "RCTARKitNodes.h"
 
@@ -15,8 +14,8 @@
 
 RCT_EXPORT_MODULE()
 
-RCT_EXPORT_METHOD(mount:(NSDictionary *)property) {
-    [[RCTARKitGeos sharedInstance] addCapsule:property];
+RCT_EXPORT_METHOD(mount:(NSDictionary *)property material:(SCNMaterial *)material) {
+    [[RCTARKitGeos sharedInstance] addCapsule:property material:material];
 }
 
 RCT_EXPORT_METHOD(unmount:(NSString *)identifier) {

--- a/ios/components/ARConeManager.m
+++ b/ios/components/ARConeManager.m
@@ -7,7 +7,6 @@
 //
 
 #import "ARConeManager.h"
-#import "RCTARKit.h"
 #import "RCTARKitGeos.h"
 #import "RCTARKitNodes.h"
 
@@ -15,8 +14,8 @@
 
 RCT_EXPORT_MODULE()
 
-RCT_EXPORT_METHOD(mount:(NSDictionary *)property) {
-    [[RCTARKitGeos sharedInstance] addCone:property];
+RCT_EXPORT_METHOD(mount:(NSDictionary *)property material:(SCNMaterial *)material) {
+    [[RCTARKitGeos sharedInstance] addCone:property material:material];
 }
 
 RCT_EXPORT_METHOD(unmount:(NSString *)identifier) {

--- a/ios/components/ARCylinderManager.m
+++ b/ios/components/ARCylinderManager.m
@@ -8,7 +8,6 @@
 //
 
 #import "ARCylinderManager.h"
-#import "RCTARKit.h"
 #import "RCTARKitGeos.h"
 #import "RCTARKitNodes.h"
 
@@ -16,8 +15,8 @@
 
 RCT_EXPORT_MODULE()
 
-RCT_EXPORT_METHOD(mount:(NSDictionary *)property) {
-    [[RCTARKitGeos sharedInstance] addCylinder:property];
+RCT_EXPORT_METHOD(mount:(NSDictionary *)property material:(SCNMaterial *)material) {
+    [[RCTARKitGeos sharedInstance] addCylinder:property material:material];
 }
 
 RCT_EXPORT_METHOD(unmount:(NSString *)identifier) {

--- a/ios/components/ARModelManager.m
+++ b/ios/components/ARModelManager.m
@@ -7,7 +7,6 @@
 //
 
 #import "ARModelManager.h"
-#import "RCTARKit.h"
 #import "RCTARKitGeos.h"
 #import "RCTARKitNodes.h"
 
@@ -15,7 +14,7 @@
 
 RCT_EXPORT_MODULE()
 
-RCT_EXPORT_METHOD(mount:(NSDictionary *)property) {
+RCT_EXPORT_METHOD(mount:(NSDictionary *)property material:(SCNMaterial *)material) {
     [[RCTARKitGeos sharedInstance] addModel:property];
 }
 

--- a/ios/components/ARPlaneManager.m
+++ b/ios/components/ARPlaneManager.m
@@ -7,7 +7,6 @@
 //
 
 #import "ARPlaneManager.h"
-#import "RCTARKit.h"
 #import "RCTARKitGeos.h"
 #import "RCTARKitNodes.h"
 
@@ -15,8 +14,8 @@
 
 RCT_EXPORT_MODULE()
 
-RCT_EXPORT_METHOD(mount:(NSDictionary *)property) {
-    [[RCTARKitGeos sharedInstance] addPlane:property];
+RCT_EXPORT_METHOD(mount:(NSDictionary *)property material:(SCNMaterial *)material) {
+    [[RCTARKitGeos sharedInstance] addPlane:property material:material];
 }
 
 RCT_EXPORT_METHOD(unmount:(NSString *)identifier) {

--- a/ios/components/ARPyramidManager.m
+++ b/ios/components/ARPyramidManager.m
@@ -7,7 +7,6 @@
 //
 
 #import "ARPyramidManager.h"
-#import "RCTARKit.h"
 #import "RCTARKitGeos.h"
 #import "RCTARKitNodes.h"
 
@@ -15,8 +14,8 @@
 
 RCT_EXPORT_MODULE()
 
-RCT_EXPORT_METHOD(mount:(NSDictionary *)property) {
-    [[RCTARKitGeos sharedInstance] addPyramid:property];
+RCT_EXPORT_METHOD(mount:(NSDictionary *)property material:(SCNMaterial *)material) {
+    [[RCTARKitGeos sharedInstance] addPyramid:property material:material];
 }
 
 RCT_EXPORT_METHOD(unmount:(NSString *)identifier) {

--- a/ios/components/ARSphereManager.m
+++ b/ios/components/ARSphereManager.m
@@ -7,7 +7,6 @@
 //
 
 #import "ARSphereManager.h"
-#import "RCTARKit.h"
 #import "RCTARKitGeos.h"
 #import "RCTARKitNodes.h"
 
@@ -15,8 +14,8 @@
 
 RCT_EXPORT_MODULE()
 
-RCT_EXPORT_METHOD(mount:(NSDictionary *)property) {
-    [[RCTARKitGeos sharedInstance] addSphere:property];
+RCT_EXPORT_METHOD(mount:(NSDictionary *)property material:(SCNMaterial *)material) {
+    [[RCTARKitGeos sharedInstance] addSphere:property material:material];
 }
 
 RCT_EXPORT_METHOD(unmount:(NSString *)identifier) {

--- a/ios/components/ARTextManager.m
+++ b/ios/components/ARTextManager.m
@@ -7,7 +7,6 @@
 //
 
 #import "ARTextManager.h"
-#import "RCTARKit.h"
 #import "RCTARKitGeos.h"
 #import "RCTARKitNodes.h"
 
@@ -15,8 +14,8 @@
 
 RCT_EXPORT_MODULE()
 
-RCT_EXPORT_METHOD(mount:(NSDictionary *)property) {
-    [[RCTARKitGeos sharedInstance] addText:property];
+RCT_EXPORT_METHOD(mount:(NSDictionary *)property material:(SCNMaterial *)material) {
+    [[RCTARKitGeos sharedInstance] addText:property material:material];
 }
 
 RCT_EXPORT_METHOD(unmount:(NSString *)identifier) {

--- a/ios/components/ARTorusManager.m
+++ b/ios/components/ARTorusManager.m
@@ -7,7 +7,6 @@
 //
 
 #import "ARTorusManager.h"
-#import "RCTARKit.h"
 #import "RCTARKitGeos.h"
 #import "RCTARKitNodes.h"
 
@@ -15,8 +14,8 @@
 
 RCT_EXPORT_MODULE()
 
-RCT_EXPORT_METHOD(mount:(NSDictionary *)property) {
-    [[RCTARKitGeos sharedInstance] addTorus:property];
+RCT_EXPORT_METHOD(mount:(NSDictionary *)property material:(SCNMaterial *)material) {
+    [[RCTARKitGeos sharedInstance] addTorus:property material:material];
 }
 
 RCT_EXPORT_METHOD(unmount:(NSString *)identifier) {

--- a/ios/components/ARTubeManager.m
+++ b/ios/components/ARTubeManager.m
@@ -7,7 +7,6 @@
 //
 
 #import "ARTubeManager.h"
-#import "RCTARKit.h"
 #import "RCTARKitGeos.h"
 #import "RCTARKitNodes.h"
 
@@ -15,8 +14,8 @@
 
 RCT_EXPORT_MODULE()
 
-RCT_EXPORT_METHOD(mount:(NSDictionary *)property) {
-    [[RCTARKitGeos sharedInstance] addTube:property];
+RCT_EXPORT_METHOD(mount:(NSDictionary *)property material:(SCNMaterial *)material) {
+    [[RCTARKitGeos sharedInstance] addTube:property material:material];
 }
 
 RCT_EXPORT_METHOD(unmount:(NSString *)identifier) {


### PR DESCRIPTION
With `[RCTConvert SCNMaterial]` implemented, the react native bridge will do type conversion automatically. So we could easily write:
```
RCT_EXPORT_METHOD(mount:(NSDictionary *)property material:(SCNMaterial *)material) {
}
```
and call it in JS as
```
*.mount(property, material);
```

The conversion of the material property is implemented. The next step is to do it for other properties such as position and rotation.

**Note**: API is slightly changed. `material.color` is renamed to `material.diffuse` so that it conforms to the `SCNMaterial` definition.