### PR TITLE
Add Basic Transition support. Update nodes in scenekits instead of remount 

### DIFF
--- a/components/lib/createArComponent.js
+++ b/components/lib/createArComponent.js
@@ -91,7 +91,6 @@ export default (mountConfig, propTypes = {}) => {
     }
 
     componentWillUnmount() {
-      console.log('unmounting', this.identifier);
       ARGeosManager.unmount(this.identifier);
     }
 

--- a/components/lib/createArComponent.js
+++ b/components/lib/createArComponent.js
@@ -68,11 +68,12 @@ export default (mountConfig, propTypes = {}) => {
       mount(this.identifier, this.props);
     }
 
-    componentDidUpdate(props) {
+    componentWillUpdate(props) {
       const changedKeys = filter(
         keys(this.props),
         key => !isDeepEqual(props[key], this.props[key]),
       );
+
       if (isEmpty(changedKeys)) {
         return;
       }
@@ -80,6 +81,7 @@ export default (mountConfig, propTypes = {}) => {
       if (some(KEYS_THAT_NEED_REMOUNT, k => changedKeys.includes(k))) {
         // remount
         // TODO: we should be able to update
+
         mount(this.identifier, props);
       } else {
         // always include transition

--- a/components/lib/propTypes.js
+++ b/components/lib/propTypes.js
@@ -10,6 +10,9 @@ export const position = PropTypes.shape({
   y: PropTypes.number,
   z: PropTypes.number,
 });
+export const transition = PropTypes.shape({
+  duration: PropTypes.number,
+});
 export const eulerAngles = PropTypes.shape({
   x: PropTypes.number,
   y: PropTypes.number,

--- a/ios/RCTARKitNodes.h
+++ b/ios/RCTARKitNodes.h
@@ -36,7 +36,7 @@ typedef NS_OPTIONS(NSUInteger, RFReferenceFrame) {
 + (instancetype)sharedInstance;
 
 - (void)addNodeToScene:(SCNNode *)node inReferenceFrame:(NSString *)referenceFrame;
-
+- (void)updateNode:(NSString *)key properties:(NSDictionary *) properties;
 - (void)registerNode:(SCNNode *)node forKey:(NSString *)key;
 - (SCNNode *)nodeForKey:(NSString *)key;
 - (void)removeNodeForKey:(NSString *)key;

--- a/ios/RCTARKitNodes.m
+++ b/ios/RCTARKitNodes.m
@@ -7,6 +7,7 @@
 //
 
 #import "RCTARKitNodes.h"
+#import "RCTConvert+ARKit.h"
 
 @implementation SCNNode (ReferenceFrame)
 @dynamic referenceFrame;
@@ -198,6 +199,14 @@ static NSDictionary * getSceneObjectHitResult(NSMutableArray *resultsMapped, con
     }
 }
 
+- (void)updateNode:(NSString *)key properties:(NSDictionary *) properties {
+     SCNNode *node = [self.nodes objectForKey:key];
+    // only basic properties like position and rotation can currently be updated this way
+    if(node) {
+        [RCTConvert setNodeProperties:node properties:properties];
+    }
+    
+}
 
 
 #pragma mark - RCTARKitSessionDelegate

--- a/ios/RCTConvert+ARKit.h
+++ b/ios/RCTConvert+ARKit.h
@@ -17,7 +17,7 @@
 @interface RCTConvert (ARKit)
 
 + (SCNMaterial *)SCNMaterial:(id)json;
-+ (void)addMaterialProperties:(SCNMaterial *)material properties:(id)json;
+
 + (SCNVector3)SCNVector3:(id)json;
 + (SCNVector4)SCNVector4:(id)json;
 + (SCNNode *)SCNNode:(id)json;
@@ -33,6 +33,9 @@
 + (SCNPlane *)SCNPlane:(id)json;
 
 + (SCNTextNode *)SCNTextNode:(id)json;
+
++ (void)setNodeProperties:(SCNNode *)node properties:(id)json;
++ (void)setMaterialProperties:(SCNMaterial *)material properties:(id)json;
 
 @end
 

--- a/ios/RCTConvert+ARKit.m
+++ b/ios/RCTConvert+ARKit.m
@@ -12,36 +12,11 @@
 
 + (SCNMaterial *)SCNMaterial:(id)json {
     SCNMaterial *material = [SCNMaterial new];
-    [self addMaterialProperties:material properties:json];
+    [self setMaterialProperties:material properties:json];
     
     return material;
 }
 
-
-+ (void)addMaterialProperties:(SCNMaterial *)material properties:(id)json {
-    if (json[@"blendMode"]) {
-        material.blendMode = (SCNBlendMode) [json[@"blendMode"] integerValue];
-    }
-    if (json[@"lightingModel"]) {
-        material.lightingModelName = json[@"lightingModel"];
-    }
-    if (json[@"diffuse"]) {
-        material.diffuse.contents = [self UIColor:json[@"diffuse"]];
-    }
-    
-    if (json[@"metalness"]) {
-        material.lightingModelName = SCNLightingModelPhysicallyBased;
-        material.metalness.contents = @([json[@"metalness"] floatValue]);
-    }
-    if (json[@"roughness"]) {
-        material.lightingModelName = SCNLightingModelPhysicallyBased;
-        material.roughness.contents = @([json[@"roughness"] floatValue]);
-    }
-    
-    if(json[@"shaders"] ) {
-        material.shaderModifiers = json[@"shaders"];
-    }
-}
 
 
 + (SCNVector3)SCNVector3:(id)json {
@@ -59,20 +34,12 @@
     return SCNVector4Make(x, y, z, w);
 }
 
+
 + (SCNNode *)SCNNode:(id)json {
     SCNNode *node = [SCNNode new];
         
     node.name = [NSString stringWithFormat:@"%@", json[@"id"]];
-    node.position = [self SCNVector3:json[@"position"]];
-    node.eulerAngles = [self SCNVector3:json[@"eulerAngles"]];
-    
-    if (json[@"orientation"]) {
-        node.orientation = [self SCNVector4:json[@"orientation"]];
-    }
-    
-    if (json[@"rotation"]) {
-        node.rotation = [self SCNVector4:json[@"rotation"]];
-    }
+    [self setNodeProperties:node properties:json];
 
     return node;
 }
@@ -186,7 +153,6 @@
     SCNMaterial *material = [self SCNMaterial:json[@"material"]];
     material.doubleSided = YES;
     geometry.materials = @[material];
-    
     return geometry;
 }
 
@@ -245,5 +211,51 @@
     
     return textNode;
 }
+
+
++ (void)setMaterialProperties:(SCNMaterial *)material properties:(id)json {
+    if (json[@"blendMode"]) {
+        material.blendMode = (SCNBlendMode) [json[@"blendMode"] integerValue];
+    }
+    if (json[@"lightingModel"]) {
+        material.lightingModelName = json[@"lightingModel"];
+    }
+    if (json[@"diffuse"]) {
+        material.diffuse.contents = [self UIColor:json[@"diffuse"]];
+    }
+    
+    if (json[@"metalness"]) {
+        material.lightingModelName = SCNLightingModelPhysicallyBased;
+        material.metalness.contents = @([json[@"metalness"] floatValue]);
+    }
+    if (json[@"roughness"]) {
+        material.lightingModelName = SCNLightingModelPhysicallyBased;
+        material.roughness.contents = @([json[@"roughness"] floatValue]);
+    }
+    
+    if(json[@"shaders"] ) {
+        material.shaderModifiers = json[@"shaders"];
+    }
+}
+
++ (void)setNodeProperties:(SCNNode *)node properties:(id)json {
+    if (json[@"position"]) {
+        node.position = [self SCNVector3:json[@"position"]];
+    }
+    
+    if (json[@"eulerAngles"]) {
+        node.eulerAngles = [self SCNVector3:json[@"eulerAngles"]];
+    }
+    
+    if (json[@"orientation"]) {
+        node.orientation = [self SCNVector4:json[@"orientation"]];
+    }
+    
+    if (json[@"rotation"]) {
+        node.rotation = [self SCNVector4:json[@"rotation"]];
+    }
+}
+
+
 
 @end

--- a/ios/RCTConvert+ARKit.m
+++ b/ios/RCTConvert+ARKit.m
@@ -239,6 +239,17 @@
 }
 
 + (void)setNodeProperties:(SCNNode *)node properties:(id)json {
+    if(json[@"transition"]) {
+        NSDictionary * transition =json[@"transition"];
+        if(transition[@"duration"]) {
+            [SCNTransaction setAnimationDuration:[transition[@"duration"] floatValue]];
+        } else {
+            [SCNTransaction setAnimationDuration:0.0];
+        }
+      
+    } else {
+        [SCNTransaction setAnimationDuration:0.0];
+    }
     if (json[@"position"]) {
         node.position = [self SCNVector3:json[@"position"]];
     }

--- a/ios/components/ARGeosManager.m
+++ b/ios/components/ARGeosManager.m
@@ -62,4 +62,8 @@ RCT_EXPORT_METHOD(unmount:(NSString *)identifier) {
     [[RCTARKitNodes sharedInstance] removeNodeForKey:identifier];
 }
 
+RCT_EXPORT_METHOD(update:(NSString *)identifier properties:(NSDictionary *) properties) {
+    [[RCTARKitNodes sharedInstance] updateNode:identifier properties:properties];
+}
+
 @end

--- a/ios/components/ARModelManager.m
+++ b/ios/components/ARModelManager.m
@@ -31,7 +31,7 @@ RCT_EXPORT_METHOD(mount:(NSDictionary *)property node:(SCNNode *)node frame:(NSS
     if(materialJson) {
         for(id idx in node.geometry.materials) {
             SCNMaterial* material = (SCNMaterial* )idx;
-            [RCTConvert addMaterialProperties:material properties:materialJson];
+            [RCTConvert setNodeProperties:material properties:materialJson];
         }
     }
     
@@ -41,7 +41,7 @@ RCT_EXPORT_METHOD(mount:(NSDictionary *)property node:(SCNNode *)node frame:(NSS
         if(materialJson) {
             for(id idx in node.geometry.materials) {
                 SCNMaterial* material = (SCNMaterial* )idx;
-                [RCTConvert addMaterialProperties:material properties:materialJson];
+                [RCTConvert setNodeProperties:material properties:materialJson];
             }
         }
     

--- a/ios/components/ARModelManager.m
+++ b/ios/components/ARModelManager.m
@@ -31,7 +31,7 @@ RCT_EXPORT_METHOD(mount:(NSDictionary *)property node:(SCNNode *)node frame:(NSS
     if(materialJson) {
         for(id idx in node.geometry.materials) {
             SCNMaterial* material = (SCNMaterial* )idx;
-            [RCTConvert setNodeProperties:material properties:materialJson];
+            [RCTConvert setMaterialProperties:material properties:materialJson];
         }
     }
     
@@ -41,7 +41,7 @@ RCT_EXPORT_METHOD(mount:(NSDictionary *)property node:(SCNNode *)node frame:(NSS
         if(materialJson) {
             for(id idx in node.geometry.materials) {
                 SCNMaterial* material = (SCNMaterial* )idx;
-                [RCTConvert setNodeProperties:material properties:materialJson];
+                [RCTConvert setMaterialProperties:material properties:materialJson];
             }
         }
     

--- a/package.json
+++ b/package.json
@@ -9,12 +9,19 @@
   "author": "Zehao Li <qft.gtr@gmail.com>",
   "license": "MIT",
   "homepage": "https://github.com/HippoAR/react-native-arkit",
-  "keywords": ["react-native", "react", "native", "ARKit", "AR"],
+  "keywords": [
+    "react-native",
+    "react",
+    "native",
+    "ARKit",
+    "AR"
+  ],
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
+    "fast-deep-equal": "^1.0.0",
     "lodash": "^4.17.4",
     "prop-types": "^15.5.7",
     "react": "16.0.0-alpha.12",


### PR DESCRIPTION


This PR improves performance in certain cases. E.g. when moving a model around. It also adds basic experimental support for **transitions**.

## Transitions

Transitions work similarly like in css. You can specify a duration and any properties change will be interpolated. You specify transitions like this:

```
  <ARKit.Box
          material={{
            diffuse: "red,
          }}
          transition={{
            duration: 0.6, // in seconds
          }}
          position={{x,y,z}}
          shape={{
              width: 1,
              height: 1,
              length: 1,
            }),
        />
```

Any change to position will now be animated within in 0.6 seconds.

At the moment only position, rotation, eulerAngles and orientation will be affected. You limit the transition to certain properties (like with transition-properties on html+css)

## Refactor & improvements

- If position, rotation, eulerAngles or orientation is changed, the node gets updated instead of remounted. 

- If shape, material or model has changed, it still remounts the component. This can be optimized later and would also allow to specify transitions between materials, e.g. colors or in shapes.

- the mounting-lifecycle has been adjusted a bit. Before, it was possible that if you change your whole scene, but mount an element with the same id as before, the new element was not visible, because `componentWillMount` on the new element is invoked before `componentWillUnmount` is called on the old one. I changed it now to `componentDidMount` and it seems to work in my case. Feedback welcome!


