### PR TITLE
remove clearscene call

### DIFF
--- a/ARKit.js
+++ b/ARKit.js
@@ -36,9 +36,7 @@ class ARKit extends Component {
     reason: 0,
     floor: null,
   };
-  componentWillMount() {
-    ARKitManager.clearScene();
-  }
+
   componentDidMount() {
     ARKitManager.resume();
   }


### PR DESCRIPTION
calling clearscene on mount will result in https://github.com/HippoAR/react-native-arkit/issues/11

removing clearscene for the time being. Usually nodes get cleaned up
properly.