### PR TITLE
allow to specify options for image capture

### DIFF
--- a/ARKit.js
+++ b/ARKit.js
@@ -156,6 +156,12 @@ Object.keys(ARKitManager).forEach(key => {
   ARKit[key] = ARKitManager[key];
 });
 
+const addDefaultsToSnapShotFunc = funcName => ({ target = 'cameraRoll' }) =>
+  ARKitManager[funcName]({ target });
+
+ARKit.snapshot = addDefaultsToSnapShotFunc('snapshot');
+ARKit.snapshotCamera = addDefaultsToSnapShotFunc('snapshotCamera');
+
 ARKit.exportModel = presetId => {
   const id = presetId || generateId();
   const property = { id };

--- a/ARKit.js
+++ b/ARKit.js
@@ -156,8 +156,10 @@ Object.keys(ARKitManager).forEach(key => {
   ARKit[key] = ARKitManager[key];
 });
 
-const addDefaultsToSnapShotFunc = funcName => ({ target = 'cameraRoll' }) =>
-  ARKitManager[funcName]({ target });
+const addDefaultsToSnapShotFunc = funcName => ({
+  target = 'cameraRoll',
+  format = 'png',
+}) => ARKitManager[funcName]({ target, format });
 
 ARKit.snapshot = addDefaultsToSnapShotFunc('snapshot');
 ARKit.snapshotCamera = addDefaultsToSnapShotFunc('snapshotCamera');

--- a/ios/RCTARKit.h
+++ b/ios/RCTARKit.h
@@ -56,8 +56,8 @@ typedef void (^RCTARKitReject)(NSString *code, NSString *message, NSError *error
 - (void)hitTestSceneObjects:(CGPoint)tapPoint resolve:(RCTARKitResolve) resolve reject:(RCTARKitReject)reject;
 - (SCNVector3)projectPoint:(SCNVector3)point;
 - (float)getCameraDistanceToPoint:(SCNVector3)point;
-- (void)snapshot:(RCTARKitResolve)resolve reject:(RCTARKitReject)reject;
-- (void)snapshotCamera:(RCTARKitResolve)resolve reject:(RCTARKitReject)reject;
+- (UIImage *)getSnaphshot;
+- (UIImage *)getSnaphshotCamera;
 - (void)focusScene;
 - (void)clearScene;
 - (NSDictionary *)readCameraPosition;

--- a/ios/RCTARKit.m
+++ b/ios/RCTARKit.m
@@ -231,40 +231,32 @@ static float getDistance(const SCNVector3 pointA, const SCNVector3 pointB) {
 }
 
 
-- (void)snapshot:(RCTARKitResolve)resolve reject:(RCTARKitReject)reject {
+- (UIImage *)getSnaphshot {
     UIImage *image = [self.arView snapshot];
-    // FIXME: I belive this is not the right way. I don't know how to pass 'resolve' to the completionSelector
-    // If you know how to do it, please PR. Thanks!
-    _resolve = resolve;
-    UIImageWriteToSavedPhotosAlbum(image, self, @selector(thisImage:savedInAlbumWithError:ctx:), NULL);
+    return image;
 }
 
 
-- (void)snapshotCamera:(RCTARKitResolve)resolve reject:(RCTARKitReject)reject {
 
-    // thx https://stackoverflow.com/a/8094038/1463534
+
+
+- (UIImage *)getSnaphsotCamera {
     CVPixelBufferRef pixelBuffer = self.arView.session.currentFrame.capturedImage;
     CIImage *ciImage = [CIImage imageWithCVPixelBuffer:pixelBuffer];
-
+    
     CIContext *temporaryContext = [CIContext contextWithOptions:nil];
     CGImageRef videoImage = [temporaryContext
                              createCGImage:ciImage
                              fromRect:CGRectMake(0, 0,
                                                  CVPixelBufferGetWidth(pixelBuffer),
                                                  CVPixelBufferGetHeight(pixelBuffer))];
-
+    
     UIImage *image = [UIImage imageWithCGImage:videoImage scale: 1.0 orientation:UIImageOrientationRight];
     CGImageRelease(videoImage);
-    _resolve = resolve;
-    UIImageWriteToSavedPhotosAlbum(image, self, @selector(thisImage:savedInAlbumWithError:ctx:), NULL);
+    return image;
 }
 
-- (void)thisImage:(UIImage *)image savedInAlbumWithError:(NSError *)error ctx:(void *)ctx {
-    if (error) {
-    } else {
-        _resolve(@{ @"success": @(YES) });
-    }
-}
+
 
 
 

--- a/ios/RCTARKitManager.m
+++ b/ios/RCTARKitManager.m
@@ -116,12 +116,12 @@ RCT_EXPORT_METHOD(
     } completionHandler:^(BOOL success, NSError *error) {
         if (success)
         {
-           
+            
             NSString * localID = placeholder.localIdentifier;
             
             NSString * assetURLStr = [self getAssetUrl:localID];
-          
-            resolve(@{@"url": assetURLStr});
+            
+            resolve(@{@"url": assetURLStr, @"width":@(image.size.width), @"height": @(image.size.height)});
         }
         else
         {
@@ -149,7 +149,7 @@ RCT_EXPORT_METHOD(
     NSString *filePath = [directory stringByAppendingPathComponent:uniqueFileName]; //Add the file name
     bool success = [data writeToFile:filePath atomically:YES]; //Write the file
     if(success) {
-        resolve(@{@"url": filePath});
+        resolve(@{@"url": filePath, @"width":@(image.size.width), @"height": @(image.size.height)});
     } else {
         // TODO use NSError from writeToFile
         reject(@"snapshot_error",  [NSString stringWithFormat:@"could not save to '%@'", filePath], nil);
@@ -176,7 +176,7 @@ RCT_EXPORT_METHOD(
             dir =  [NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES) firstObject];
         } else if([target isEqualToString:@"documents"]) {
             dir =  [NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES) firstObject];
-
+            
         } else {
             dir = target;
         }
@@ -232,3 +232,4 @@ RCT_EXPORT_METHOD(clearScene:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseR
 }
 
 @end
+


### PR DESCRIPTION
`ARKit.snapshot` and `ARKit.snapshotCamera` can now take options.

There is only one option at the moment:

*target*: the directory where to store the image

- `cameraRoll` (default) store file in the cameraRoll
- `cache` store file in cache directory
- `documents` store file in documents directory
- an absolute path (not tested yet)

the function returns now a promise with the following result object:

- `url`: the file url of the image. Its the given target directory plus a random filename. If target was cameraRoll, this is an untested asset-url ;-) 
- `width`, `height` the size of the image