### PR TITLE
onFeaturesDetected callback

### DIFF
--- a/ARKit.js
+++ b/ARKit.js
@@ -175,7 +175,7 @@ ARKit.propTypes = {
   planeDetection: PropTypes.bool,
   lightEstimation: PropTypes.bool,
   onPlaneDetected: PropTypes.func,
-  onFrameUpdate: PropTypes.func,
+  onFeaturesDetected: PropTypes.func,
   onPlaneUpdate: PropTypes.func,
   onTrackingState: PropTypes.func,
   onTapOnPlaneUsingExtent: PropTypes.func,

--- a/ios/RCTARKit.h
+++ b/ios/RCTARKit.h
@@ -38,7 +38,7 @@ typedef void (^RCTARKitReject)(NSString *code, NSString *message, NSError *error
 @property (nonatomic, assign) BOOL lightEstimation;
 
 @property (nonatomic, copy) RCTBubblingEventBlock onPlaneDetected;
-@property (nonatomic, copy) RCTBubblingEventBlock onFrameUpdate;
+@property (nonatomic, copy) RCTBubblingEventBlock onFeaturesDetected;
 @property (nonatomic, copy) RCTBubblingEventBlock onPlaneUpdate;
 @property (nonatomic, copy) RCTBubblingEventBlock onTrackingState;
 @property (nonatomic, copy) RCTBubblingEventBlock onTapOnPlaneUsingExtent;

--- a/ios/RCTARKit.m
+++ b/ios/RCTARKit.m
@@ -41,7 +41,7 @@ void dispatch_once_on_main_thread(dispatch_once_t *predicate,
 + (instancetype)sharedInstance {
     static RCTARKit *instance = nil;
     static dispatch_once_t onceToken;
-
+    
     dispatch_once_on_main_thread(&onceToken, ^{
         if (instance == nil) {
             ARSCNView *arView = [[ARSCNView alloc] init];
@@ -54,30 +54,30 @@ void dispatch_once_on_main_thread(dispatch_once_t *predicate,
 - (instancetype)initWithARView:(ARSCNView *)arView {
     if ((self = [super init])) {
         self.arView = arView;
-
+        
         // delegates
         arView.delegate = self;
         arView.session.delegate = self;
-
+        
         UITapGestureRecognizer *tapGestureRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleTapFrom:)];
         tapGestureRecognizer.numberOfTapsRequired = 1;
         [self.arView addGestureRecognizer:tapGestureRecognizer];
-
+        
         self.touchDelegates = [NSMutableArray array];
         self.rendererDelegates = [NSMutableArray array];
         self.sessionDelegates = [NSMutableArray array];
-
+        
         // nodeManager
         self.nodeManager = [RCTARKitNodes sharedInstance];
         self.nodeManager.arView = arView;
         [self.sessionDelegates addObject:self.nodeManager];
-
+        
         // configuration(s)
         arView.autoenablesDefaultLighting = YES;
         arView.scene.rootNode.name = @"root";
-
+        
         self.planes = [NSMutableDictionary new];
-
+        
         // start ARKit
         [self addSubview:arView];
         [self resume];
@@ -191,7 +191,7 @@ static float getDistance(const SCNVector3 pointA, const SCNVector3 pointB) {
     float yd = pointB.y - pointA.y;
     float zd = pointB.z - pointA.z;
     float distance = sqrt(xd * xd + yd * yd + zd * zd);
-
+    
     if (distance < 0){
         return (distance * -1);
     } else {
@@ -201,7 +201,7 @@ static float getDistance(const SCNVector3 pointA, const SCNVector3 pointB) {
 
 - (float)getCameraDistanceToPoint:(SCNVector3)point {
     return getDistance(self.nodeManager.cameraOrigin.position, point);
-
+    
 }
 
 
@@ -212,12 +212,12 @@ static float getDistance(const SCNVector3 pointA, const SCNVector3 pointB) {
     if (_configuration) {
         return _configuration;
     }
-
+    
     if (!ARWorldTrackingConfiguration.isSupported) {}
-
+    
     _configuration = [ARWorldTrackingConfiguration new];
     _configuration.planeDetection = ARPlaneDetectionHorizontal;
-
+    
     return _configuration;
 }
 
@@ -226,7 +226,7 @@ static float getDistance(const SCNVector3 pointA, const SCNVector3 pointB) {
 #pragma mark - snapshot methods
 
 - (void)hitTestSceneObjects:(const CGPoint)tapPoint resolve:(RCTARKitResolve)resolve reject:(RCTARKitReject)reject {
-
+    
     resolve([self.nodeManager getSceneObjectsHitResult:tapPoint]);
 }
 
@@ -263,7 +263,7 @@ static float getDistance(const SCNVector3 pointA, const SCNVector3 pointB) {
 #pragma mark - plane hit detection
 
 - (void)hitTestPlane:(const CGPoint)tapPoint types:(ARHitTestResultType)types resolve:(RCTARKitResolve)resolve reject:(RCTARKitReject)reject {
-
+    
     resolve([self getPlaneHitResult:tapPoint types:types]);
 }
 
@@ -278,7 +278,7 @@ static NSMutableArray * mapHitResults(NSArray<ARHitTestResult *> *results) {
                                             @"y": @(result.worldTransform.columns[3].y),
                                             @"z": @(result.worldTransform.columns[3].z)
                                             }
-
+                                    
                                     } )];
     }];
     return resultsMapped;
@@ -315,7 +315,7 @@ static NSDictionary * getPlaneHitResult(NSMutableArray *resultsMapped, const CGP
         NSDictionary * planeHitResult = [self getPlaneHitResult:tapPoint types:ARHitTestResultTypeExistingPlaneUsingExtent];
         self.onTapOnPlaneUsingExtent(planeHitResult);
     }
-
+    
     if(self.onTapOnPlaneNoExtent) {
         // Take the screen space tap coordinates and pass them to the hitTest method on the ARSCNView instance
         NSDictionary * planeHitResult = [self getPlaneHitResult:tapPoint types:ARHitTestResultTypeExistingPlane];
@@ -343,17 +343,18 @@ static NSDictionary * getPlaneHitResult(NSMutableArray *resultsMapped, const CGP
     }
 }
 
+
 - (void)renderer:(id <SCNSceneRenderer>)renderer didAddNode:(SCNNode *)node forAnchor:(ARAnchor *)anchor {
     if (![anchor isKindOfClass:[ARPlaneAnchor class]]) {
         return;
     }
-
+    
     SCNNode *parent = [node parentNode];
     NSLog(@"plane detected");
     //    NSLog(@"%f %f %f", parent.position.x, parent.position.y, parent.position.z);
-
+    
     ARPlaneAnchor *planeAnchor = (ARPlaneAnchor *)anchor;
-
+    
     //    NSLog(@"%@", @{
     //            @"id": planeAnchor.identifier.UUIDString,
     //            @"alignment": @(planeAnchor.alignment),
@@ -362,7 +363,7 @@ static NSDictionary * getPlaneHitResult(NSMutableArray *resultsMapped, const CGP
     //            @"extent": @{ @"x": @(planeAnchor.extent.x), @"y": @(planeAnchor.extent.y), @"z": @(planeAnchor.extent.z) },
     //            @"camera": @{ @"x": @(self.cameraOrigin.position.x), @"y": @(self.cameraOrigin.position.y), @"z": @(self.cameraOrigin.position.z) }
     //            });
-
+    
     if (self.onPlaneDetected) {
         self.onPlaneDetected(@{
                                @"id": planeAnchor.identifier.UUIDString,
@@ -373,7 +374,7 @@ static NSDictionary * getPlaneHitResult(NSMutableArray *resultsMapped, const CGP
                                //                               @"camera": @{ @"x": @(self.cameraOrigin.position.x), @"y": @(self.cameraOrigin.position.y), @"z": @(self.cameraOrigin.position.z) }
                                });
     }
-
+    
     //Plane *plane = [[Plane alloc] initWithAnchor: (ARPlaneAnchor *)anchor isHidden: NO];
     //[self.planes setObject:plane forKey:anchor.identifier];
     //[node addChildNode:plane];
@@ -384,13 +385,13 @@ static NSDictionary * getPlaneHitResult(NSMutableArray *resultsMapped, const CGP
 
 - (void)renderer:(id <SCNSceneRenderer>)renderer didUpdateNode:(SCNNode *)node forAnchor:(ARAnchor *)anchor {
     ARPlaneAnchor *planeAnchor = (ARPlaneAnchor *)anchor;
-
+    
     SCNNode *parent = [node parentNode];
     //    NSLog(@"%@", parent.name);
     //    NSLog(@"%f %f %f", node.position.x, node.position.y, node.position.z);
     //    NSLog(@"%f %f %f %f", node.rotation.x, node.rotation.y, node.rotation.z, node.rotation.w);
-
-
+    
+    
     //    NSLog(@"%@", @{
     //                   @"id": planeAnchor.identifier.UUIDString,
     //                   @"alignment": @(planeAnchor.alignment),
@@ -399,7 +400,7 @@ static NSDictionary * getPlaneHitResult(NSMutableArray *resultsMapped, const CGP
     //                   @"extent": @{ @"x": @(planeAnchor.extent.x), @"y": @(planeAnchor.extent.y), @"z": @(planeAnchor.extent.z) },
     //                   @"camera": @{ @"x": @(self.cameraOrigin.position.x), @"y": @(self.cameraOrigin.position.y), @"z": @(self.cameraOrigin.position.z) }
     //                   });
-
+    
     if (self.onPlaneUpdate) {
         self.onPlaneUpdate(@{
                              @"id": planeAnchor.identifier.UUIDString,
@@ -410,12 +411,12 @@ static NSDictionary * getPlaneHitResult(NSMutableArray *resultsMapped, const CGP
                              //                             @"camera": @{ @"x": @(self.cameraOrigin.position.x), @"y": @(self.cameraOrigin.position.y), @"z": @(self.cameraOrigin.position.z) }
                              });
     }
-
+    
     Plane *plane = [self.planes objectForKey:anchor.identifier];
     if (plane == nil) {
         return;
     }
-
+    
     [plane update:(ARPlaneAnchor *)anchor];
 }
 
@@ -433,12 +434,32 @@ static NSDictionary * getPlaneHitResult(NSMutableArray *resultsMapped, const CGP
             [sessionDelegate session:session didUpdateFrame:frame];
         }
     }
-    if (self.onFrameUpdate) {
+    if (self.onFeaturesDetected) {
         dispatch_async(dispatch_get_main_queue(), ^{
-            self.onFrameUpdate(@{});
+            
+            NSMutableArray * featurePoints = [NSMutableArray array];
+            for (int i = 0; i < frame.rawFeaturePoints.count; i++) {
+                vector_float3 point = frame.rawFeaturePoints.points[i];
+                
+                NSString * pointId = [NSString stringWithFormat:@"featurepoint_%lld",frame.rawFeaturePoints.identifiers[i]];
+                
+                [featurePoints addObject:@{
+                                           @"x": @(point[0]),
+                                           @"y": @(point[1]),
+                                           @"z": @(point[2]),
+                                           @"id":pointId,
+                                           }];
+                
+            }
+            
+            self.onFeaturesDetected(@{
+                                      @"featurePoints":featurePoints
+                                      });
         });
     }
 }
+
+
 
 - (void)session:(ARSession *)session cameraDidChangeTrackingState:(ARCamera *)camera {
     if (self.onTrackingState) {

--- a/ios/RCTARKitManager.m
+++ b/ios/RCTARKitManager.m
@@ -62,7 +62,7 @@ RCT_EXPORT_VIEW_PROPERTY(lightEstimation, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(onPlaneDetected, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onPlaneUpdate, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onTrackingState, RCTBubblingEventBlock)
-RCT_EXPORT_VIEW_PROPERTY(onFrameUpdate, RCTBubblingEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onFeaturesDetected, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onEvent, RCTBubblingEventBlock)
 
 RCT_EXPORT_METHOD(pause:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {

--- a/ios/RCTARKitNodes.m
+++ b/ios/RCTARKitNodes.m
@@ -218,6 +218,7 @@ static NSDictionary * getSceneObjectHitResult(NSMutableArray *resultsMapped, con
     self.cameraOrigin.eulerAngles = SCNVector3Make(0, atan2f(z.x, z.z), 0);
     self.frontOfCamera.position = SCNVector3Make(pos.x - focDistance * z.x, pos.y  - focDistance * z.y, pos.z - focDistance * z.z);
     self.frontOfCamera.eulerAngles = self.cameraOrigin.eulerAngles;
+    
 }
 
 @end


### PR DESCRIPTION
adds a callback on the ARKit component that notifies about new feature-points. The main use for that is to show custom feature-points (see https://stackoverflow.com/questions/46121994/how-to-change-the-appearance-of-arscndebugoptions-featurepoints)

You can get the feature points from the callback:

```
  <ARKit
     // ...
      onFeaturesDetected={
        e => {
              const { featurePoints } = e.nativeEvent
              // featurePoints is an array of objects {x,y,z, id} 
              // do what every you want with them, e.g. update redux with the features
             // WARNING: this is called often, if you are using redux-devtools you should blacklist this event.
              setFeaturesDetected(featurePoints)
            }
      }
```

the current implementation calls the callback on every frame, even if the features have not changed. This might get optimized later