### PR TITLE
readd clearscene (again)

### DIFF
--- a/ARKit.js
+++ b/ARKit.js
@@ -36,7 +36,9 @@ class ARKit extends Component {
     reason: 0,
     floor: null,
   };
-
+  componentWillMount() {
+    ARKitManager.clearScene();
+  }
   componentDidMount() {
     ARKitManager.resume();
   }


### PR DESCRIPTION
i readded the clearscene which led to the infamous https://github.com/HippoAR/react-native-arkit/issues/11. This has been fixed.

the clearscene is  needed, when you are developing and your js process crashes, but the underlying app is still running. In this situations old nodes on the scene were not removed.