### PR TITLE
Shapes

### DIFF
--- a/ARKit.js
+++ b/ARKit.js
@@ -13,7 +13,7 @@ import {
   View,
   Text,
   NativeModules,
-  requireNativeComponent,
+  requireNativeComponent
 } from 'react-native';
 
 import generateId from './components/lib/generateId';
@@ -26,7 +26,7 @@ const TRACKING_REASONS = [
   'NONE',
   'INITIALIZING',
   'EXCESSIVE_MOTION',
-  'INSUFFICIENT_FEATURES',
+  'INSUFFICIENT_FEATURES'
 ];
 const TRACKING_STATES_COLOR = ['red', 'orange', 'green'];
 
@@ -34,7 +34,7 @@ class ARKit extends Component {
   state = {
     state: 0,
     reason: 0,
-    floor: null,
+    floor: null
   };
   componentWillMount() {
     ARKitManager.clearScene();
@@ -55,7 +55,7 @@ class ARKit extends Component {
           <View
             style={[
               styles.stateIcon,
-              { backgroundColor: TRACKING_STATES_COLOR[this.state.state] },
+              { backgroundColor: TRACKING_STATES_COLOR[this.state.state] }
             ]}
           />
           <Text style={styles.stateText}>
@@ -84,13 +84,13 @@ class ARKit extends Component {
   _onTrackingState = ({
     state = this.state.state,
     reason = this.state.reason,
-    floor,
+    floor
   }) => {
     if (this.props.onTrackingState) {
       this.props.onTrackingState({
         state: TRACKING_STATES[state] || state,
         reason: TRACKING_REASONS[reason] || reason,
-        floor,
+        floor
       });
     }
 
@@ -98,7 +98,7 @@ class ARKit extends Component {
       this.setState({
         state,
         reason,
-        floor: floor ? floor.toFixed(2) : this.state.floor,
+        floor: floor ? floor.toFixed(2) : this.state.floor
       });
     }
   };
@@ -138,19 +138,19 @@ const styles = StyleSheet.create({
     borderRadius: 10,
     padding: 4,
     backgroundColor: 'black',
-    flexDirection: 'row',
+    flexDirection: 'row'
   },
   stateIcon: {
     width: 12,
     height: 12,
     borderRadius: 6,
-    marginRight: 4,
+    marginRight: 4
   },
   stateText: {
     color: 'white',
     fontSize: 10,
-    height: 12,
-  },
+    height: 12
+  }
 });
 
 // copy all ARKitManager properties to ARKit
@@ -160,7 +160,7 @@ Object.keys(ARKitManager).forEach(key => {
 
 const addDefaultsToSnapShotFunc = funcName => ({
   target = 'cameraRoll',
-  format = 'png',
+  format = 'png'
 }) => ARKitManager[funcName]({ target, format });
 
 ARKit.snapshot = addDefaultsToSnapShotFunc('snapshot');
@@ -182,7 +182,7 @@ ARKit.propTypes = {
   onTrackingState: PropTypes.func,
   onTapOnPlaneUsingExtent: PropTypes.func,
   onTapOnPlaneNoExtent: PropTypes.func,
-  onEvent: PropTypes.func,
+  onEvent: PropTypes.func
 };
 
 const RCTARKit = requireNativeComponent('RCTARKit', ARKit);

--- a/README.md
+++ b/README.md
@@ -23,15 +23,18 @@ There is a Slack group that anyone can join for help / support / general questio
 
 `$ react-native link react-native-arkit`
 
+! Currently automatic installation does not work as PocketSVG is missing. Follow the manual installation
+
 ### Manual installation
 
 
 #### iOS
 
 1. In XCode, in the project navigator, right click `Libraries` ➜ `Add Files to [your project's name]`
-2. Go to `node_modules` ➜ `react-native-arkit` and add `RCTARKit.xcodeproj`
-3. In XCode, in the project navigator, select your project. Add `libRCTARKit.a` to your project's `Build Phases` ➜ `Link Binary With Libraries`
-4. Run your project (`Cmd+R`)<
+2. Go to `node_modules` ➜ add `react-native-arkit/RCTARKit.xcodeproj` and `_PocketSVG/_PocketSVG.xcodeproj`
+3. In XCode, in the project navigator, select your project. Add `libRCTARKit.a` `and PocketSVG.framework` to your project's `Build Phases` ➜ `Link Binary With Libraries`
+4. In Tab `General` ➜ `Embedded Binaries` ➜ `+` ➜ Add `PocketSVG.framework ios`
+5. Run your project (`Cmd+R`)<
 
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -103,11 +103,32 @@ export default class ReactNativeARKit extends Component {
           />
           <ARKit.Model
             position={{ x: -0.2, y: 0, z: 0, frame: 'local' }}
+            scale={0.01},
             model={{
               file: 'art.scnassets/ship.scn', // make sure you have the model file in the ios project
-              scale: 0.01,
             }}
           />
+          <ARKit.Shape
+            position={{ x: -1, y: 0, z: 0 }}
+            eulerAngles={{
+              x: Math.PI,
+            }}
+            scale={0.01}
+            shape={{
+              // specify shape by svg! See https://github.com/HippoAR/react-native-arkit/pull/89 for details
+              pathSvg: `
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+                <path d="M50,30c9-22 42-24 48,0c5,40-40,40-48,65c-8-25-54-25-48-65c 6-24 39-22 48,0 z" fill="#F00" stroke="#000"/>
+              </svg>`,
+              pathFlatness: 0.1,
+              // it's also possible to specify a chamfer profile:
+              chamferRadius: 5,
+              chamferProfilePathSvg: `
+                <path d="M.6 94.4c.7-7 0-13 6-18.5 1.6-1.4 5.3 1 6-.8l9.6 2.3C25 70.8 20.2 63 21 56c0-1.3 2.3-1 3.5-.7 7.6 1.4 7 15.6 14.7 13.2 1-.2 1.7-1 2-2 2-5-11.3-28.8-3-30.3 2.3-.4 5.7 1.8 6.7 0l8.4 6.5c.3-.4-8-17.3-2.4-21.6 7-5.4 14 5.3 17.7 7.8 1 .8 3 2 3.8 1 6.3-10-6-8.5-3.2-19 2-8.2 18.2-2.3 20.3-3 2.4-.6 1.7-5.6 4.2-6.4"/>
+              `,
+              extrusion: 10,
+            }}
+          />  
         </ARKit>
       </View>
     );
@@ -275,6 +296,20 @@ SceneKit only supports `.scn` and `.dae` formats.
 | `position` | `{ x, y, z }` |
 | `eulerAngles` | `{ x, y, z }` |
 | `model` | `{ file, node, scale, alpha }` |
+
+#### `<ARKit.Shape />`
+
+Creates a extruded shape by an svg path.
+See https://github.com/HippoAR/react-native-arkit/pull/89 for details
+
+##### Props
+
+| Prop | Type |
+|---|---|
+| `position` | `{ x, y, z }` |
+| `eulerAngles` | `{ x, y, z }` |
+| `shape` | `{ pathSvg, extrusion, pathFlatness, chamferRadius, chamferProfilePathSvg, chamferProfilePathFlatness }` |
+
 
 
 ## Contributing

--- a/components/ARShape.js
+++ b/components/ARShape.js
@@ -1,0 +1,12 @@
+import PropTypes from 'prop-types';
+
+import createArComponent from './lib/createArComponent';
+
+const ARShape = createArComponent('addShape', {
+  shape: PropTypes.shape({
+    extrusion: PropTypes.number,
+    path: PropTypes.string
+  })
+});
+
+module.exports = ARShape;

--- a/components/ARShape.js
+++ b/components/ARShape.js
@@ -1,11 +1,17 @@
 import PropTypes from 'prop-types';
 
+import { chamferMode } from './lib/propTypes';
 import createArComponent from './lib/createArComponent';
 
 const ARShape = createArComponent('addShape', {
   shape: PropTypes.shape({
     extrusion: PropTypes.number,
-    path: PropTypes.string
+    pathSvg: PropTypes.string,
+    pathFlatness: PropTypes.number,
+    chamferMode,
+    chamferRadius: PropTypes.number,
+    chamferProfilePathSvg: PropTypes.string,
+    chamferProfilePathFlatness: PropTypes.string
   })
 });
 

--- a/components/ARSprite.js
+++ b/components/ARSprite.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import withAnimationFrame from 'react-animation-frame';
+import withAnimationFrame from '@panter/react-animation-frame';
 
 import { NativeModules, Animated } from 'react-native';
 
@@ -13,7 +13,7 @@ const ARSprite = withAnimationFrame(
       super(props);
       this.state = {
         zIndex: new Animated.Value(),
-        pos2D: new Animated.ValueXY(), // inits to zero
+        pos2D: new Animated.ValueXY() // inits to zero
       };
     }
     onAnimationFrame() {
@@ -22,9 +22,9 @@ const ARSprite = withAnimationFrame(
           {
             x: this.state.pos2D.x,
             y: this.state.pos2D.y,
-            z: this.state.zIndex,
-          },
-        ]),
+            z: this.state.zIndex
+          }
+        ])
       );
     }
 
@@ -34,18 +34,18 @@ const ARSprite = withAnimationFrame(
           style={{
             position: 'absolute',
             transform: this.state.pos2D.getTranslateTransform(),
-            ...this.props.style,
+            ...this.props.style
           }}
         >
           {this.props.children}
         </Animated.View>
       );
     }
-  },
+  }
 );
 
 ARSprite.propTypes = {
-  position,
+  position
 };
 
 module.exports = ARSprite;

--- a/components/lib/createArComponent.js
+++ b/components/lib/createArComponent.js
@@ -15,7 +15,7 @@ import {
   orientation,
   position,
   rotation,
-  transition,
+  transition
 } from './propTypes';
 import { processColorInMaterial } from './parseColor';
 import generateId from './generateId';
@@ -25,14 +25,15 @@ const NODE_PROPS = [
   'position',
   'eulerAngles',
   'rotation',
+  'scale',
   'orientation',
-  'transition',
+  'transition'
 ];
 const KEYS_THAT_NEED_REMOUNT = ['material', 'shape', 'model'];
 
 const nodeProps = (id, props) => ({
   id,
-  ...pick(props, NODE_PROPS),
+  ...pick(props, NODE_PROPS)
 });
 
 export default (mountConfig, propTypes = {}) => {
@@ -40,11 +41,11 @@ export default (mountConfig, propTypes = {}) => {
     typeof mountConfig === 'string'
       ? {
           shape: props.shape,
-          material: processColorInMaterial(props.material),
+          material: processColorInMaterial(props.material)
         }
       : {
           ...pick(props, mountConfig.pick),
-          material: processColorInMaterial(props.material),
+          material: processColorInMaterial(props.material)
         };
 
   const mountFunc =
@@ -56,7 +57,7 @@ export default (mountConfig, propTypes = {}) => {
     mountFunc(
       getShapeAndMaterialProps(props),
       nodeProps(id, props),
-      props.frame,
+      props.frame
     );
   };
 
@@ -71,7 +72,7 @@ export default (mountConfig, propTypes = {}) => {
     componentWillUpdate(props) {
       const changedKeys = filter(
         keys(this.props),
-        key => !isDeepEqual(props[key], this.props[key]),
+        key => !isDeepEqual(props[key], this.props[key])
       );
 
       if (isEmpty(changedKeys)) {
@@ -87,7 +88,7 @@ export default (mountConfig, propTypes = {}) => {
         // always include transition
         ARGeosManager.update(
           this.identifier,
-          pick(props, ['transition', ...changedKeys]),
+          pick(props, ['transition', ...changedKeys])
         );
       }
     }
@@ -108,7 +109,7 @@ export default (mountConfig, propTypes = {}) => {
     rotation,
     orientation,
     material,
-    ...propTypes,
+    ...propTypes
   };
 
   return ARComponent;

--- a/components/lib/propTypes.js
+++ b/components/lib/propTypes.js
@@ -8,43 +8,44 @@ const ARKitManager = NativeModules.ARKitManager;
 export const position = PropTypes.shape({
   x: PropTypes.number,
   y: PropTypes.number,
-  z: PropTypes.number,
+  z: PropTypes.number
 });
 export const transition = PropTypes.shape({
-  duration: PropTypes.number,
+  duration: PropTypes.number
 });
 export const eulerAngles = PropTypes.shape({
   x: PropTypes.number,
   y: PropTypes.number,
-  z: PropTypes.number,
+  z: PropTypes.number
 });
 
 export const rotation = PropTypes.shape({
   x: PropTypes.number,
   y: PropTypes.number,
   z: PropTypes.number,
-  w: PropTypes.number,
+  w: PropTypes.number
 });
 
 export const orientation = PropTypes.shape({
   x: PropTypes.number,
   y: PropTypes.number,
   z: PropTypes.number,
-  w: PropTypes.number,
+  w: PropTypes.number
 });
 
 export const shaders = PropTypes.shape({
   [ARKitManager.ShaderModifierEntryPoint.Geometry]: PropTypes.string,
   [ARKitManager.ShaderModifierEntryPoint.Surface]: PropTypes.string,
   [ARKitManager.ShaderModifierEntryPoint.LightingModel]: PropTypes.string,
-  [ARKitManager.ShaderModifierEntryPoint.Fragment]: PropTypes.string,
+  [ARKitManager.ShaderModifierEntryPoint.Fragment]: PropTypes.string
 });
 
 export const lightingModel = PropTypes.oneOf(
-  values(ARKitManager.LightingModel),
+  values(ARKitManager.LightingModel)
 );
 
 export const blendMode = PropTypes.oneOf(values(ARKitManager.BlendMode));
+export const chamferMode = PropTypes.oneOf(values(ARKitManager.ChamferMode));
 
 export const material = PropTypes.shape({
   color: PropTypes.string,
@@ -52,5 +53,5 @@ export const material = PropTypes.shape({
   roughness: PropTypes.number,
   blendMode,
   lightingModel,
-  shaders,
+  shaders
 });

--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ import ARText from './components/ARText';
 import ARModel from './components/ARModel';
 import ARSprite from './components/ARSprite';
 import ARGroup from './components/ARGroup';
+import ARShape from './components/ARShape';
 
 ARKit.Box = ARBox;
 ARKit.Sphere = ARSphere;
@@ -35,6 +36,7 @@ ARKit.Text = ARText;
 ARKit.Model = ARModel;
 ARKit.Sprite = ARSprite;
 ARKit.Group = ARGroup;
+ARKit.Shape = ARShape;
 
 module.exports = {
   ARKit,
@@ -50,5 +52,5 @@ module.exports = {
   ARPlane,
   ARText,
   ARModel,
-  ARGroup,
+  ARGroup
 };

--- a/ios/RCTARKit.m
+++ b/ios/RCTARKit.m
@@ -451,10 +451,11 @@ static NSDictionary * getPlaneHitResult(NSMutableArray *resultsMapped, const CGP
                                            }];
                 
             }
-            
+            if(self.onFeaturesDetected) {
             self.onFeaturesDetected(@{
                                       @"featurePoints":featurePoints
                                       });
+            }
         });
     }
 }

--- a/ios/RCTARKit.m
+++ b/ios/RCTARKit.m
@@ -435,26 +435,27 @@ static NSDictionary * getPlaneHitResult(NSMutableArray *resultsMapped, const CGP
         }
     }
     if (self.onFeaturesDetected) {
+        NSMutableArray * featurePoints = [NSMutableArray array];
+        for (int i = 0; i < frame.rawFeaturePoints.count; i++) {
+            vector_float3 point = frame.rawFeaturePoints.points[i];
+            
+            NSString * pointId = [NSString stringWithFormat:@"featurepoint_%lld",frame.rawFeaturePoints.identifiers[i]];
+            
+            [featurePoints addObject:@{
+                                       @"x": @(point[0]),
+                                       @"y": @(point[1]),
+                                       @"z": @(point[2]),
+                                       @"id":pointId,
+                                       }];
+            
+        }
         dispatch_async(dispatch_get_main_queue(), ^{
             
-            NSMutableArray * featurePoints = [NSMutableArray array];
-            for (int i = 0; i < frame.rawFeaturePoints.count; i++) {
-                vector_float3 point = frame.rawFeaturePoints.points[i];
-                
-                NSString * pointId = [NSString stringWithFormat:@"featurepoint_%lld",frame.rawFeaturePoints.identifiers[i]];
-                
-                [featurePoints addObject:@{
-                                           @"x": @(point[0]),
-                                           @"y": @(point[1]),
-                                           @"z": @(point[2]),
-                                           @"id":pointId,
-                                           }];
-                
-            }
+            
             if(self.onFeaturesDetected) {
-            self.onFeaturesDetected(@{
-                                      @"featurePoints":featurePoints
-                                      });
+                self.onFeaturesDetected(@{
+                                          @"featurePoints":featurePoints
+                                          });
             }
         });
     }

--- a/ios/RCTARKit.xcodeproj/project.pbxproj
+++ b/ios/RCTARKit.xcodeproj/project.pbxproj
@@ -16,21 +16,21 @@
 		10ED47A71F38BC01004DF043 /* DeviceMotion.m in Sources */ = {isa = PBXBuildFile; fileRef = 10ED47A61F38BC00004DF043 /* DeviceMotion.m */; };
 		10FEF6141F774C9000EC21AE /* RCTARKitIO.m in Sources */ = {isa = PBXBuildFile; fileRef = 10FEF6101F774C8F00EC21AE /* RCTARKitIO.m */; };
 		10FEF6151F774C9000EC21AE /* RCTARKitNodes.m in Sources */ = {isa = PBXBuildFile; fileRef = 10FEF6121F774C9000EC21AE /* RCTARKitNodes.m */; };
-		B13FF7611F94F72400A6C92B /* PocketSVG.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B13FF75D1F94F71500A6C92B /* PocketSVG.framework */; };
+		B14F3AF71F94F8BA00B73842 /* PocketSVG.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B14F3AF41F94F8B100B73842 /* PocketSVG.framework */; };
 		B3E7B58A1CC2AC0600A0062D /* RCTARKit.m in Sources */ = {isa = PBXBuildFile; fileRef = B3E7B5891CC2AC0600A0062D /* RCTARKit.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		B13FF75C1F94F71500A6C92B /* PBXContainerItemProxy */ = {
+		B14F3AF31F94F8B100B73842 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = B13FF7571F94F71500A6C92B /* PocketSVG.xcodeproj */;
+			containerPortal = B14F3AEE1F94F8B100B73842 /* PocketSVG.xcodeproj */;
 			proxyType = 2;
 			remoteGlobalIDString = C79800BB1A21CB5300380860;
 			remoteInfo = "PocketSVG (iOS)";
 		};
-		B13FF75E1F94F71500A6C92B /* PBXContainerItemProxy */ = {
+		B14F3AF51F94F8B100B73842 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = B13FF7571F94F71500A6C92B /* PocketSVG.xcodeproj */;
+			containerPortal = B14F3AEE1F94F8B100B73842 /* PocketSVG.xcodeproj */;
 			proxyType = 2;
 			remoteGlobalIDString = C79800F51A21CDFD00380860;
 			remoteInfo = "PocketSVG (Mac)";
@@ -70,7 +70,7 @@
 		10FEF6121F774C9000EC21AE /* RCTARKitNodes.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RCTARKitNodes.m; sourceTree = "<group>"; };
 		10FEF6131F774C9000EC21AE /* RCTARKitDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RCTARKitDelegate.h; sourceTree = "<group>"; };
 		134814201AA4EA6300B7C361 /* libRCTARKit.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libRCTARKit.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		B13FF7571F94F71500A6C92B /* PocketSVG.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = PocketSVG.xcodeproj; path = ../_PocketSVG/PocketSVG.xcodeproj; sourceTree = "<group>"; };
+		B14F3AEE1F94F8B100B73842 /* PocketSVG.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = PocketSVG.xcodeproj; path = ../../_PocketSVG/PocketSVG.xcodeproj; sourceTree = "<group>"; };
 		B3E7B5881CC2AC0600A0062D /* RCTARKit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTARKit.h; sourceTree = "<group>"; };
 		B3E7B5891CC2AC0600A0062D /* RCTARKit.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTARKit.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -80,7 +80,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B13FF7611F94F72400A6C92B /* PocketSVG.framework in Frameworks */,
+				B14F3AF71F94F8BA00B73842 /* PocketSVG.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -136,18 +136,9 @@
 		B11601B61F94F34700030B9A /* Libraries */ = {
 			isa = PBXGroup;
 			children = (
-				B13FF7571F94F71500A6C92B /* PocketSVG.xcodeproj */,
+				B14F3AEE1F94F8B100B73842 /* PocketSVG.xcodeproj */,
 			);
 			name = Libraries;
-			sourceTree = "<group>";
-		};
-		B13FF7581F94F71500A6C92B /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				B13FF75D1F94F71500A6C92B /* PocketSVG.framework */,
-				B13FF75F1F94F71500A6C92B /* PocketSVG.framework */,
-			);
-			name = Products;
 			sourceTree = "<group>";
 		};
 		B13FF7601F94F72400A6C92B /* Frameworks */ = {
@@ -155,6 +146,15 @@
 			children = (
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		B14F3AEF1F94F8B100B73842 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				B14F3AF41F94F8B100B73842 /* PocketSVG.framework */,
+				B14F3AF61F94F8B100B73842 /* PocketSVG.framework */,
+			);
+			name = Products;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -203,8 +203,8 @@
 			projectDirPath = "";
 			projectReferences = (
 				{
-					ProductGroup = B13FF7581F94F71500A6C92B /* Products */;
-					ProjectRef = B13FF7571F94F71500A6C92B /* PocketSVG.xcodeproj */;
+					ProductGroup = B14F3AEF1F94F8B100B73842 /* Products */;
+					ProjectRef = B14F3AEE1F94F8B100B73842 /* PocketSVG.xcodeproj */;
 				},
 			);
 			projectRoot = "";
@@ -215,18 +215,18 @@
 /* End PBXProject section */
 
 /* Begin PBXReferenceProxy section */
-		B13FF75D1F94F71500A6C92B /* PocketSVG.framework */ = {
+		B14F3AF41F94F8B100B73842 /* PocketSVG.framework */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.framework;
 			path = PocketSVG.framework;
-			remoteRef = B13FF75C1F94F71500A6C92B /* PBXContainerItemProxy */;
+			remoteRef = B14F3AF31F94F8B100B73842 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		B13FF75F1F94F71500A6C92B /* PocketSVG.framework */ = {
+		B14F3AF61F94F8B100B73842 /* PocketSVG.framework */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.framework;
 			path = PocketSVG.framework;
-			remoteRef = B13FF75E1F94F71500A6C92B /* PBXContainerItemProxy */;
+			remoteRef = B14F3AF51F94F8B100B73842 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 /* End PBXReferenceProxy section */

--- a/ios/RCTARKit.xcodeproj/project.pbxproj
+++ b/ios/RCTARKit.xcodeproj/project.pbxproj
@@ -19,23 +19,6 @@
 		B3E7B58A1CC2AC0600A0062D /* RCTARKit.m in Sources */ = {isa = PBXBuildFile; fileRef = B3E7B5891CC2AC0600A0062D /* RCTARKit.m */; };
 /* End PBXBuildFile section */
 
-/* Begin PBXContainerItemProxy section */
-		B14F3AF31F94F8B100B73842 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = B14F3AEE1F94F8B100B73842 /* PocketSVG.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = C79800BB1A21CB5300380860;
-			remoteInfo = "PocketSVG (iOS)";
-		};
-		B14F3AF51F94F8B100B73842 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = B14F3AEE1F94F8B100B73842 /* PocketSVG.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = C79800F51A21CDFD00380860;
-			remoteInfo = "PocketSVG (Mac)";
-		};
-/* End PBXContainerItemProxy section */
-
 /* Begin PBXCopyFilesBuildPhase section */
 		58B511D91A9E6C8500147676 /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
@@ -78,7 +61,8 @@
 		10FEF6121F774C9000EC21AE /* RCTARKitNodes.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RCTARKitNodes.m; sourceTree = "<group>"; };
 		10FEF6131F774C9000EC21AE /* RCTARKitDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RCTARKitDelegate.h; sourceTree = "<group>"; };
 		134814201AA4EA6300B7C361 /* libRCTARKit.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libRCTARKit.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		B14F3AEE1F94F8B100B73842 /* PocketSVG.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = PocketSVG.xcodeproj; path = ../../_PocketSVG/PocketSVG.xcodeproj; sourceTree = "<group>"; };
+		B14C36631F960C500047CB67 /* PocketSVG.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PocketSVG.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		B14C36651F960C6E0047CB67 /* PocketSVG.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PocketSVG.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B3E7B5881CC2AC0600A0062D /* RCTARKit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTARKit.h; sourceTree = "<group>"; };
 		B3E7B5891CC2AC0600A0062D /* RCTARKit.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTARKit.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -118,7 +102,6 @@
 		58B511D21A9E6C8500147676 = {
 			isa = PBXGroup;
 			children = (
-				B11601B61F94F34700030B9A /* Libraries */,
 				106999E21F3EC2FB00032829 /* components */,
 				10ED47A51F38BC00004DF043 /* DeviceMotion.h */,
 				10ED47A61F38BC00004DF043 /* DeviceMotion.m */,
@@ -140,28 +123,13 @@
 			);
 			sourceTree = "<group>";
 		};
-		B11601B61F94F34700030B9A /* Libraries */ = {
-			isa = PBXGroup;
-			children = (
-				B14F3AEE1F94F8B100B73842 /* PocketSVG.xcodeproj */,
-			);
-			name = Libraries;
-			sourceTree = "<group>";
-		};
 		B13FF7601F94F72400A6C92B /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				B14C36651F960C6E0047CB67 /* PocketSVG.framework */,
+				B14C36631F960C500047CB67 /* PocketSVG.framework */,
 			);
 			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		B14F3AEF1F94F8B100B73842 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				B14F3AF41F94F8B100B73842 /* PocketSVG.framework */,
-				B14F3AF61F94F8B100B73842 /* PocketSVG.framework */,
-			);
-			name = Products;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -209,35 +177,12 @@
 			mainGroup = 58B511D21A9E6C8500147676;
 			productRefGroup = 58B511D21A9E6C8500147676;
 			projectDirPath = "";
-			projectReferences = (
-				{
-					ProductGroup = B14F3AEF1F94F8B100B73842 /* Products */;
-					ProjectRef = B14F3AEE1F94F8B100B73842 /* PocketSVG.xcodeproj */;
-				},
-			);
 			projectRoot = "";
 			targets = (
 				58B511DA1A9E6C8500147676 /* RCTARKit */,
 			);
 		};
 /* End PBXProject section */
-
-/* Begin PBXReferenceProxy section */
-		B14F3AF41F94F8B100B73842 /* PocketSVG.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = PocketSVG.framework;
-			remoteRef = B14F3AF31F94F8B100B73842 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		B14F3AF61F94F8B100B73842 /* PocketSVG.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = PocketSVG.framework;
-			remoteRef = B14F3AF51F94F8B100B73842 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-/* End PBXReferenceProxy section */
 
 /* Begin PBXSourcesBuildPhase section */
 		58B511D71A9E6C8500147676 /* Sources */ = {

--- a/ios/RCTARKit.xcodeproj/project.pbxproj
+++ b/ios/RCTARKit.xcodeproj/project.pbxproj
@@ -16,7 +16,6 @@
 		10ED47A71F38BC01004DF043 /* DeviceMotion.m in Sources */ = {isa = PBXBuildFile; fileRef = 10ED47A61F38BC00004DF043 /* DeviceMotion.m */; };
 		10FEF6141F774C9000EC21AE /* RCTARKitIO.m in Sources */ = {isa = PBXBuildFile; fileRef = 10FEF6101F774C8F00EC21AE /* RCTARKitIO.m */; };
 		10FEF6151F774C9000EC21AE /* RCTARKitNodes.m in Sources */ = {isa = PBXBuildFile; fileRef = 10FEF6121F774C9000EC21AE /* RCTARKitNodes.m */; };
-		B14F3AF71F94F8BA00B73842 /* PocketSVG.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B14F3AF41F94F8B100B73842 /* PocketSVG.framework */; };
 		B3E7B58A1CC2AC0600A0062D /* RCTARKit.m in Sources */ = {isa = PBXBuildFile; fileRef = B3E7B5891CC2AC0600A0062D /* RCTARKit.m */; };
 /* End PBXBuildFile section */
 
@@ -43,6 +42,15 @@
 			buildActionMask = 2147483647;
 			dstPath = "include/$(PRODUCT_NAME)";
 			dstSubfolderSpec = 16;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B14C363A1F9504D70047CB67 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -80,7 +88,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B14F3AF71F94F8BA00B73842 /* PocketSVG.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -167,6 +174,7 @@
 				58B511D71A9E6C8500147676 /* Sources */,
 				58B511D81A9E6C8500147676 /* Frameworks */,
 				58B511D91A9E6C8500147676 /* CopyFiles */,
+				B14C363A1F9504D70047CB67 /* CopyFiles */,
 			);
 			buildRules = (
 			);
@@ -338,6 +346,7 @@
 					"$(SRCROOT)/../../react-native-arcl/ios",
 					../../../ios/Pods/Headers/Public/,
 					../../../ios/Pods/Headers/Public/React,
+					"$(SRCROOT)/../../_PocketSVG/**",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
@@ -359,6 +368,7 @@
 					"$(SRCROOT)/../../react-native-arcl/ios",
 					../../../ios/Pods/Headers/Public/,
 					../../../ios/Pods/Headers/Public/React,
+					"$(SRCROOT)/../../_PocketSVG/**",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LIBRARY_SEARCH_PATHS = "$(inherited)";

--- a/ios/RCTARKit.xcodeproj/project.pbxproj
+++ b/ios/RCTARKit.xcodeproj/project.pbxproj
@@ -16,8 +16,26 @@
 		10ED47A71F38BC01004DF043 /* DeviceMotion.m in Sources */ = {isa = PBXBuildFile; fileRef = 10ED47A61F38BC00004DF043 /* DeviceMotion.m */; };
 		10FEF6141F774C9000EC21AE /* RCTARKitIO.m in Sources */ = {isa = PBXBuildFile; fileRef = 10FEF6101F774C8F00EC21AE /* RCTARKitIO.m */; };
 		10FEF6151F774C9000EC21AE /* RCTARKitNodes.m in Sources */ = {isa = PBXBuildFile; fileRef = 10FEF6121F774C9000EC21AE /* RCTARKitNodes.m */; };
+		B13FF7611F94F72400A6C92B /* PocketSVG.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B13FF75D1F94F71500A6C92B /* PocketSVG.framework */; };
 		B3E7B58A1CC2AC0600A0062D /* RCTARKit.m in Sources */ = {isa = PBXBuildFile; fileRef = B3E7B5891CC2AC0600A0062D /* RCTARKit.m */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		B13FF75C1F94F71500A6C92B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = B13FF7571F94F71500A6C92B /* PocketSVG.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = C79800BB1A21CB5300380860;
+			remoteInfo = "PocketSVG (iOS)";
+		};
+		B13FF75E1F94F71500A6C92B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = B13FF7571F94F71500A6C92B /* PocketSVG.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = C79800F51A21CDFD00380860;
+			remoteInfo = "PocketSVG (Mac)";
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
 		58B511D91A9E6C8500147676 /* CopyFiles */ = {
@@ -52,6 +70,7 @@
 		10FEF6121F774C9000EC21AE /* RCTARKitNodes.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RCTARKitNodes.m; sourceTree = "<group>"; };
 		10FEF6131F774C9000EC21AE /* RCTARKitDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RCTARKitDelegate.h; sourceTree = "<group>"; };
 		134814201AA4EA6300B7C361 /* libRCTARKit.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libRCTARKit.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		B13FF7571F94F71500A6C92B /* PocketSVG.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = PocketSVG.xcodeproj; path = ../_PocketSVG/PocketSVG.xcodeproj; sourceTree = "<group>"; };
 		B3E7B5881CC2AC0600A0062D /* RCTARKit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTARKit.h; sourceTree = "<group>"; };
 		B3E7B5891CC2AC0600A0062D /* RCTARKit.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTARKit.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -61,6 +80,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B13FF7611F94F72400A6C92B /* PocketSVG.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -91,6 +111,7 @@
 		58B511D21A9E6C8500147676 = {
 			isa = PBXGroup;
 			children = (
+				B11601B61F94F34700030B9A /* Libraries */,
 				106999E21F3EC2FB00032829 /* components */,
 				10ED47A51F38BC00004DF043 /* DeviceMotion.h */,
 				10ED47A61F38BC00004DF043 /* DeviceMotion.m */,
@@ -108,7 +129,32 @@
 				105F124C1F7C0718006D4BA3 /* RCTConvert+ARKit.h */,
 				105F124D1F7C0718006D4BA3 /* RCTConvert+ARKit.m */,
 				134814211AA4EA7D00B7C361 /* Products */,
+				B13FF7601F94F72400A6C92B /* Frameworks */,
 			);
+			sourceTree = "<group>";
+		};
+		B11601B61F94F34700030B9A /* Libraries */ = {
+			isa = PBXGroup;
+			children = (
+				B13FF7571F94F71500A6C92B /* PocketSVG.xcodeproj */,
+			);
+			name = Libraries;
+			sourceTree = "<group>";
+		};
+		B13FF7581F94F71500A6C92B /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				B13FF75D1F94F71500A6C92B /* PocketSVG.framework */,
+				B13FF75F1F94F71500A6C92B /* PocketSVG.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		B13FF7601F94F72400A6C92B /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -155,12 +201,35 @@
 			mainGroup = 58B511D21A9E6C8500147676;
 			productRefGroup = 58B511D21A9E6C8500147676;
 			projectDirPath = "";
+			projectReferences = (
+				{
+					ProductGroup = B13FF7581F94F71500A6C92B /* Products */;
+					ProjectRef = B13FF7571F94F71500A6C92B /* PocketSVG.xcodeproj */;
+				},
+			);
 			projectRoot = "";
 			targets = (
 				58B511DA1A9E6C8500147676 /* RCTARKit */,
 			);
 		};
 /* End PBXProject section */
+
+/* Begin PBXReferenceProxy section */
+		B13FF75D1F94F71500A6C92B /* PocketSVG.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = PocketSVG.framework;
+			remoteRef = B13FF75C1F94F71500A6C92B /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		B13FF75F1F94F71500A6C92B /* PocketSVG.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = PocketSVG.framework;
+			remoteRef = B13FF75E1F94F71500A6C92B /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+/* End PBXReferenceProxy section */
 
 /* Begin PBXSourcesBuildPhase section */
 		58B511D71A9E6C8500147676 /* Sources */ = {

--- a/ios/RCTARKitManager.m
+++ b/ios/RCTARKitManager.m
@@ -51,6 +51,12 @@ RCT_EXPORT_MODULE()
                      @"Screen": [@(SCNBlendModeScreen) stringValue],
                      @"Replace": [@(SCNBlendModeReplace) stringValue],
                      
+                     },
+             @"ChamferMode": @{
+                     @"Both": [@(SCNChamferModeBoth) stringValue],
+                     @"Back": [@(SCNChamferModeBack) stringValue],
+                     @"Front": [@(SCNChamferModeBack) stringValue],
+                     
                      }
              };
 }

--- a/ios/RCTConvert+ARKit.h
+++ b/ios/RCTConvert+ARKit.h
@@ -31,6 +31,7 @@
 + (SCNTorus *)SCNTorus:(id)json;
 + (SCNCapsule *)SCNCapsule:(id)json;
 + (SCNPlane *)SCNPlane:(id)json;
++ (SCNShape * )SCNShape:(id)json;
 
 + (SCNTextNode *)SCNTextNode:(id)json;
 

--- a/ios/RCTConvert+ARKit.m
+++ b/ios/RCTConvert+ARKit.m
@@ -188,8 +188,6 @@
     
     if (shape[@"pathFlatness"]) {
         path.flatness = [shape[@"pathFlatness"] floatValue];
-    } else {
-        path.flatness = 0.01;
     }
     CGFloat extrusion = [shape[@"extrusion"] floatValue];
     SCNShape *geometry = [SCNShape shapeWithPath:path extrusionDepth:extrusion];
@@ -206,7 +204,19 @@
         if(shape[@"chamferProfilePathFlatness"]) {
             path.flatness = [shape[@"chamferProfilePathFlatness"] floatValue];
         }
-        geometry.chamferProfile = path;
+        // normalize path
+        CGRect boundingBox = path.bounds;
+        if(path.bounds.size.width !=0 && path.bounds.size.height != 0) {
+            CGFloat scaleX = 1/boundingBox.size.width;
+            CGFloat scaleY =  scaleY = 1/boundingBox.size.height;
+            
+            CGAffineTransform transform = CGAffineTransformMakeScale(scaleX, scaleY);
+            [path applyTransform:transform];
+            geometry.chamferProfile = path;
+        } else {
+            NSLog(@"Invalid chamferProfilePathFlatness");
+        }
+       
     }
     
     

--- a/ios/RCTConvert+ARKit.m
+++ b/ios/RCTConvert+ARKit.m
@@ -7,6 +7,7 @@
 //
 
 #import "RCTConvert+ARKit.h"
+#import "SVGBezierPath.h"
 
 @implementation RCTConvert (ARKit)
 
@@ -167,6 +168,30 @@
     return geometry;
 }
 
++ (SCNShape * )SCNShape:(id)json {
+    NSDictionary* shape = json[@"shape"];
+    NSString * pathString =shape[@"path"];
+
+    NSArray * paths = [SVGBezierPath pathsFromSVGString:pathString];
+    SVGBezierPath * fullPath;
+    for(SVGBezierPath *path in paths) {
+        if(!fullPath) {
+            fullPath = path;
+        } else {
+            [fullPath appendPath:path];
+        }
+    }
+   
+    fullPath.flatness = 0.01;
+    CGFloat extrusion = [shape[@"extrusion"] floatValue];
+    SCNShape *geometry = [SCNShape shapeWithPath:fullPath extrusionDepth:extrusion];
+    
+    SCNMaterial *material = [self SCNMaterial:json[@"material"]];
+    material.doubleSided = YES;
+    geometry.materials = @[material];
+    return geometry;
+}
+
 
 + (SCNTextNode *)SCNTextNode:(id)json {
     // init SCNText
@@ -263,6 +288,12 @@
     }
     if (json[@"position"]) {
         node.position = [self SCNVector3:json[@"position"]];
+    }
+    
+    if (json[@"scale"]) {
+        CGFloat scale = [json[@"scale"] floatValue];
+        node.scale = SCNVector3Make(scale, scale, scale);
+  
     }
     
     if (json[@"eulerAngles"]) {

--- a/ios/components/ARGeosManager.m
+++ b/ios/components/ARGeosManager.m
@@ -58,6 +58,11 @@ RCT_EXPORT_METHOD(addPlane:(SCNPlane *)geometry node:(SCNNode *)node frame:(NSSt
     [[RCTARKitNodes sharedInstance] addNodeToScene:node inReferenceFrame:frame];
 }
 
+RCT_EXPORT_METHOD(addShape:(SCNShape *)geometry node:(SCNNode *)node frame:(NSString *)frame) {
+    node.geometry = geometry;
+    [[RCTARKitNodes sharedInstance] addNodeToScene:node inReferenceFrame:frame];
+}
+
 RCT_EXPORT_METHOD(unmount:(NSString *)identifier) {
     [[RCTARKitNodes sharedInstance] removeNodeForKey:identifier];
 }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
+    "_PocketSVG": "https://github.com/pocketsvg/PocketSVG",
     "fast-deep-equal": "^1.0.0",
     "lodash": "^4.17.4",
     "prop-types": "^15.5.7",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "lodash": "^4.17.4",
     "prop-types": "^15.5.7",
     "react": "16.0.0-alpha.12",
-    "react-animation-frame": "^0.3.5"
+    "@panter/react-animation-frame": "^0.3.6"
   },
   "devDependencies": {
     "babel-eslint": "^7.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,10 @@
 # yarn lockfile v1
 
 
+"_PocketSVG@https://github.com/pocketsvg/PocketSVG":
+  version "0.0.0"
+  resolved "https://github.com/pocketsvg/PocketSVG#e6d84ddeb11f99c4420e354ebb9fd34db2cf507a"
+
 acorn-jsx@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-3.0.1.tgz#afdf9488fb1ecefc8348f6fb22f464e32a58b36b"


### PR DESCRIPTION
fixes https://github.com/HippoAR/react-native-arkit/issues/80

adds basic support for shapes. A shape is a path that gets extruded. You can use svg to define the path. It uses https://github.com/pocketsvg/PocketSVG under the hood.

Also adds scale property for every geometry.

E.g: 

```
<ARKit.Shape
        position={{ x: 0, y: 0, z: 0 }}
        eulerAngles={{
          x: Math.PI,
        }}
        scale={0.01}
        shape={{
          pathSvg: `
          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
            <path d="M50,30c9-22 42-24 48,0c5,40-40,40-48,65c-8-25-54-25-48-65c 6-24 39-22 48,0 z" fill="#F00" stroke="#000"/>
          </svg>`,
          pathFlatness: 0.1,
          chamferRadius: 5,
          chamferProfilePathSvg: `
            <path d="M.6 94.4c.7-7 0-13 6-18.5 1.6-1.4 5.3 1 6-.8l9.6 2.3C25 70.8 20.2 63 21 56c0-1.3 2.3-1 3.5-.7 7.6 1.4 7 15.6 14.7 13.2 1-.2 1.7-1 2-2 2-5-11.3-28.8-3-30.3 2.3-.4 5.7 1.8 6.7 0l8.4 6.5c.3-.4-8-17.3-2.4-21.6 7-5.4 14 5.3 17.7 7.8 1 .8 3 2 3.8 1 6.3-10-6-8.5-3.2-19 2-8.2 18.2-2.3 20.3-3 2.4-.6 1.7-5.6 4.2-6.4"/>
          `,
          extrusion: 10,
        }}
      />
    </ARKit>
```

not every svg spec is supported. Paths like above work best. Basic elements like circle and rectangle should work as well. If there are multiple paths in the svg, they get concatinated.

If the svg does not render properly, try to use https://jakearchibald.github.io/svgomg/ to simplify the svg. Als try experimenting with the Precision in svgom. Setting it too low might also cause some paths to not show up.

Most svg are in pixel coordinates, so they will render very large on arkit (arkit 1 unit = 1 meter). Use the new scale-property to scale it down. Don't try to scale down the sizes in the svg, because there is a lower limit for how precise the svg will get rendered. Also experiment with different float values for `pathFlatness` (defaults to 0.6). See also this comment: https://stackoverflow.com/questions/28597275/how-to-set-the-level-of-detail-smoothness-subdivision-rate-for-scnshape#comment76976130_28600934

Additionally, you can specify chamferRadius and chamferProfileSvgPath. chamferProfileSvgPath takes a svg which should describe a path from [1,0] to [0, 1]. It will be scaled to 1 if its larger or smaller than this. See the chamferProfileSvgPath in action in the image below.

TODO: 

- [x] add all properties of SCNShape
- [x] rename path property to svg or similar
- [x] find a good way to include PocketSVG dependency

I could need some advice on the last point. I did not want to add https://github.com/pocketsvg/PocketSVG through cocoapods, because i don't know how that works properly on a library project that might get used without cocoapods. Instead i added it to package.json as a "fake package": `  "_PocketSVG": "https://github.com/pocketsvg/PocketSVG"`

this will download the package into node_modules on install and can be added as library project. However adding it needs some additional step and i managed to get it work, but i am unsure what's the best practise.



![076074ff-b50f-4005-9de2-93643e112add](https://user-images.githubusercontent.com/1972353/31637408-e02a176e-b2ce-11e7-8c9b-b30e83635f07.PNG)

NEW: with chamferProfile:

![f5919a32-e0b5-425e-abfe-733c67beae08](https://user-images.githubusercontent.com/1972353/31663693-4347c6d8-b343-11e7-8768-9c6aca2fd2b1.PNG)



