### PR TITLE
add hoc withProjectedPosition

### DIFF
--- a/ARKit.js
+++ b/ARKit.js
@@ -13,7 +13,7 @@ import {
   View,
   Text,
   NativeModules,
-  requireNativeComponent
+  requireNativeComponent,
 } from 'react-native';
 
 import generateId from './components/lib/generateId';
@@ -26,7 +26,7 @@ const TRACKING_REASONS = [
   'NONE',
   'INITIALIZING',
   'EXCESSIVE_MOTION',
-  'INSUFFICIENT_FEATURES'
+  'INSUFFICIENT_FEATURES',
 ];
 const TRACKING_STATES_COLOR = ['red', 'orange', 'green'];
 
@@ -34,7 +34,7 @@ class ARKit extends Component {
   state = {
     state: 0,
     reason: 0,
-    floor: null
+    floor: null,
   };
   componentWillMount() {
     ARKitManager.clearScene();
@@ -55,7 +55,7 @@ class ARKit extends Component {
           <View
             style={[
               styles.stateIcon,
-              { backgroundColor: TRACKING_STATES_COLOR[this.state.state] }
+              { backgroundColor: TRACKING_STATES_COLOR[this.state.state] },
             ]}
           />
           <Text style={styles.stateText}>
@@ -84,13 +84,13 @@ class ARKit extends Component {
   _onTrackingState = ({
     state = this.state.state,
     reason = this.state.reason,
-    floor
+    floor,
   }) => {
     if (this.props.onTrackingState) {
       this.props.onTrackingState({
         state: TRACKING_STATES[state] || state,
         reason: TRACKING_REASONS[reason] || reason,
-        floor
+        floor,
       });
     }
 
@@ -98,7 +98,7 @@ class ARKit extends Component {
       this.setState({
         state,
         reason,
-        floor: floor ? floor.toFixed(2) : this.state.floor
+        floor: floor ? floor.toFixed(2) : this.state.floor,
       });
     }
   };
@@ -138,19 +138,19 @@ const styles = StyleSheet.create({
     borderRadius: 10,
     padding: 4,
     backgroundColor: 'black',
-    flexDirection: 'row'
+    flexDirection: 'row',
   },
   stateIcon: {
     width: 12,
     height: 12,
     borderRadius: 6,
-    marginRight: 4
+    marginRight: 4,
   },
   stateText: {
     color: 'white',
     fontSize: 10,
-    height: 12
-  }
+    height: 12,
+  },
 });
 
 // copy all ARKitManager properties to ARKit
@@ -160,7 +160,7 @@ Object.keys(ARKitManager).forEach(key => {
 
 const addDefaultsToSnapShotFunc = funcName => ({
   target = 'cameraRoll',
-  format = 'png'
+  format = 'png',
 }) => ARKitManager[funcName]({ target, format });
 
 ARKit.snapshot = addDefaultsToSnapShotFunc('snapshot');
@@ -182,7 +182,7 @@ ARKit.propTypes = {
   onTrackingState: PropTypes.func,
   onTapOnPlaneUsingExtent: PropTypes.func,
   onTapOnPlaneNoExtent: PropTypes.func,
-  onEvent: PropTypes.func
+  onEvent: PropTypes.func,
 };
 
 const RCTARKit = requireNativeComponent('RCTARKit', ARKit);

--- a/README.md
+++ b/README.md
@@ -311,6 +311,96 @@ See https://github.com/HippoAR/react-native-arkit/pull/89 for details
 | `shape` | `{ pathSvg, extrusion, pathFlatness, chamferRadius, chamferProfilePathSvg, chamferProfilePathFlatness }` |
 
 
+### HOCs (higher order components)
+
+#### withProjectedPosition()
+
+this hoc allows you to create 3D components where the position is always at the same point on the screen, but sticks to a plane or object.
+
+Think about a 3D cursor that can be moved across your table or a 3D cursor on a wall.
+
+You can use the hoc like this:
+
+```
+const Cursor3D = withProjectedPosition()(({positionProjected, projectionResult}) => {
+  if(!projectionResult) {
+    // nothing has been hit, don't render it
+    return null;
+  }
+  return (
+    <ARKit.Sphere
+      position={positionProjected}
+      shape={{
+        radius: 0.1
+        }}
+    />
+  )
+})
+
+```
+
+Now you can your 3D cursor like this:
+
+##### Attach to a given detected horizontal plane
+
+Given you have detected a plane with onPlaneDetected, you can make the cursor stick to that plane:
+
+```
+<Cursor3D projectPosition={{
+  x: windowWidth / 2,
+  y: windowHeight / 2,
+  plane: "my-planeId"
+  }}
+/>
+
+```
+
+If you don't have the id, but want to place the cursor on a certain plane (e.g. the first or last one), pass a function for plane. This function will get all hit-results and you can return the one you need:
+
+```
+<Cursor3D projectPosition={{
+  x: windowWidth / 2,
+  y: windowHeight / 2,
+  plane: (results) => results.length > 0 ? results[0] : null
+  }}
+/>
+
+```
+
+It uses https://developer.apple.com/documentation/arkit/arframe/2875718-hittest with some default options. Please file an issue or send a PR if you need more control over the options here!
+
+##### Attach to a given 3D object
+
+You can attach the cursor on a 3D object, e.g. a non-horizontal-plane or similar:
+
+Given there is some 3D object on your scene with `id="my-nodeId"`
+
+```
+<Cursor3D projectPosition={{
+  x: windowWidth / 2,
+  y: windowHeight / 2,
+  node: "my-nodeId"
+  }}
+/>
+```
+
+Like with planes, you can select the node with a function.
+
+E.gl you have several "walls" with ids "wall_1", "wall_2", etc.
+
+```
+<Cursor3D projectPosition={{
+  x: windowWidth / 2,
+  y: windowHeight / 2,
+  node: results => results.find(r => r.id.startsWith('wall_')),
+  }}
+/>
+```
+
+
+It uses https://developer.apple.com/documentation/scenekit/scnscenerenderer/1522929-hittest with some default options. Please file an issue or send a PR if you need more control over the options here!
+
+
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ See https://github.com/HippoAR/react-native-arkit/pull/89 for details
 
 #### withProjectedPosition()
 
-this hoc allows you to create 3D components where the position is always at the same point on the screen, but sticks to a plane or object.
+this hoc allows you to create 3D components where the position is always relative to the same point on the screen/camera, but sticks to a plane or object.
 
 Think about a 3D cursor that can be moved across your table or a 3D cursor on a wall.
 

--- a/components/ARSprite.js
+++ b/components/ARSprite.js
@@ -13,7 +13,7 @@ const ARSprite = withAnimationFrame(
       super(props);
       this.state = {
         zIndex: new Animated.Value(),
-        pos2D: new Animated.ValueXY() // inits to zero
+        pos2D: new Animated.ValueXY(), // inits to zero
       };
     }
     onAnimationFrame() {
@@ -22,9 +22,9 @@ const ARSprite = withAnimationFrame(
           {
             x: this.state.pos2D.x,
             y: this.state.pos2D.y,
-            z: this.state.zIndex
-          }
-        ])
+            z: this.state.zIndex,
+          },
+        ]),
       );
     }
 
@@ -34,18 +34,18 @@ const ARSprite = withAnimationFrame(
           style={{
             position: 'absolute',
             transform: this.state.pos2D.getTranslateTransform(),
-            ...this.props.style
+            ...this.props.style,
           }}
         >
           {this.props.children}
         </Animated.View>
       );
     }
-  }
+  },
 );
 
 ARSprite.propTypes = {
-  position
+  position,
 };
 
 module.exports = ARSprite;

--- a/components/lib/createArComponent.js
+++ b/components/lib/createArComponent.js
@@ -1,6 +1,4 @@
 import { Component } from 'react';
-
-import withAnimationFrame from 'react-animation-frame';
 import PropTypes from 'prop-types';
 import filter from 'lodash/filter';
 import isDeepEqual from 'fast-deep-equal';
@@ -11,15 +9,13 @@ import some from 'lodash/some';
 
 import { NativeModules } from 'react-native';
 
-const ARKitManager = NativeModules.ARKitManager;
-
 import {
   eulerAngles,
   material,
   orientation,
   position,
   rotation,
-  transition
+  transition,
 } from './propTypes';
 import { processColorInMaterial } from './parseColor';
 import generateId from './generateId';
@@ -31,13 +27,13 @@ const NODE_PROPS = [
   'rotation',
   'scale',
   'orientation',
-  'transition'
+  'transition',
 ];
 const KEYS_THAT_NEED_REMOUNT = ['material', 'shape', 'model'];
 
 const nodeProps = (id, props) => ({
   id,
-  ...pick(props, NODE_PROPS)
+  ...pick(props, NODE_PROPS),
 });
 
 export default (mountConfig, propTypes = {}) => {
@@ -45,11 +41,11 @@ export default (mountConfig, propTypes = {}) => {
     typeof mountConfig === 'string'
       ? {
           shape: props.shape,
-          material: processColorInMaterial(props.material)
+          material: processColorInMaterial(props.material),
         }
       : {
           ...pick(props, mountConfig.pick),
-          material: processColorInMaterial(props.material)
+          material: processColorInMaterial(props.material),
         };
 
   const mountFunc =
@@ -61,7 +57,7 @@ export default (mountConfig, propTypes = {}) => {
     mountFunc(
       getShapeAndMaterialProps(props),
       nodeProps(id, props),
-      props.frame
+      props.frame,
     );
   };
 
@@ -77,7 +73,7 @@ export default (mountConfig, propTypes = {}) => {
     componentWillUpdate(props) {
       const changedKeys = filter(
         keys(this.props),
-        key => !isDeepEqual(props[key], this.props[key])
+        key => !isDeepEqual(props[key], this.props[key]),
       );
 
       if (isEmpty(changedKeys)) {
@@ -93,7 +89,7 @@ export default (mountConfig, propTypes = {}) => {
         // always include transition
         ARGeosManager.update(
           this.identifier,
-          pick(props, ['transition', ...changedKeys])
+          pick(props, ['transition', ...changedKeys]),
         );
       }
     }
@@ -115,7 +111,7 @@ export default (mountConfig, propTypes = {}) => {
     rotation,
     orientation,
     material,
-    ...propTypes
+    ...propTypes,
   };
 
   return ARComponent;

--- a/components/lib/createArComponent.js
+++ b/components/lib/createArComponent.js
@@ -1,4 +1,6 @@
 import { Component } from 'react';
+
+import withAnimationFrame from 'react-animation-frame';
 import PropTypes from 'prop-types';
 import filter from 'lodash/filter';
 import isDeepEqual from 'fast-deep-equal';
@@ -8,6 +10,8 @@ import pick from 'lodash/pick';
 import some from 'lodash/some';
 
 import { NativeModules } from 'react-native';
+
+const ARKitManager = NativeModules.ARKitManager;
 
 import {
   eulerAngles,
@@ -63,9 +67,10 @@ export default (mountConfig, propTypes = {}) => {
 
   const ARComponent = class extends Component {
     identifier = null;
-
+    animationIsRunning = true;
     componentDidMount() {
       this.identifier = this.props.id || generateId();
+
       mount(this.identifier, this.props);
     }
 
@@ -101,6 +106,7 @@ export default (mountConfig, propTypes = {}) => {
       return null;
     }
   };
+
   ARComponent.propTypes = {
     frame: PropTypes.string,
     position,

--- a/components/lib/createArComponent.js
+++ b/components/lib/createArComponent.js
@@ -63,7 +63,6 @@ export default (mountConfig, propTypes = {}) => {
 
   const ARComponent = class extends Component {
     identifier = null;
-    animationIsRunning = true;
     componentDidMount() {
       this.identifier = this.props.id || generateId();
 

--- a/components/lib/generateId.js
+++ b/components/lib/generateId.js
@@ -3,6 +3,7 @@
 const digits = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
 
 function toSex(num, base) {
+  /* eslint no-param-reassign:0 */
   if (base) {
     num = parseInt(num, base);
   }

--- a/components/lib/parseColor.js
+++ b/components/lib/parseColor.js
@@ -1,5 +1,6 @@
 import { processColor } from 'react-native';
 
+/* eslint import/prefer-default-export: 0 */
 export function processColorInMaterial(material) {
   if (!material) {
     return material;

--- a/components/lib/propTypes.js
+++ b/components/lib/propTypes.js
@@ -8,40 +8,40 @@ const ARKitManager = NativeModules.ARKitManager;
 export const position = PropTypes.shape({
   x: PropTypes.number,
   y: PropTypes.number,
-  z: PropTypes.number
+  z: PropTypes.number,
 });
 export const transition = PropTypes.shape({
-  duration: PropTypes.number
+  duration: PropTypes.number,
 });
 export const eulerAngles = PropTypes.shape({
   x: PropTypes.number,
   y: PropTypes.number,
-  z: PropTypes.number
+  z: PropTypes.number,
 });
 
 export const rotation = PropTypes.shape({
   x: PropTypes.number,
   y: PropTypes.number,
   z: PropTypes.number,
-  w: PropTypes.number
+  w: PropTypes.number,
 });
 
 export const orientation = PropTypes.shape({
   x: PropTypes.number,
   y: PropTypes.number,
   z: PropTypes.number,
-  w: PropTypes.number
+  w: PropTypes.number,
 });
 
 export const shaders = PropTypes.shape({
   [ARKitManager.ShaderModifierEntryPoint.Geometry]: PropTypes.string,
   [ARKitManager.ShaderModifierEntryPoint.Surface]: PropTypes.string,
   [ARKitManager.ShaderModifierEntryPoint.LightingModel]: PropTypes.string,
-  [ARKitManager.ShaderModifierEntryPoint.Fragment]: PropTypes.string
+  [ARKitManager.ShaderModifierEntryPoint.Fragment]: PropTypes.string,
 });
 
 export const lightingModel = PropTypes.oneOf(
-  values(ARKitManager.LightingModel)
+  values(ARKitManager.LightingModel),
 );
 
 export const blendMode = PropTypes.oneOf(values(ARKitManager.BlendMode));
@@ -53,5 +53,5 @@ export const material = PropTypes.shape({
   roughness: PropTypes.number,
   blendMode,
   lightingModel,
-  shaders
+  shaders,
 });

--- a/hocs/withProjectedPosition.js
+++ b/hocs/withProjectedPosition.js
@@ -9,7 +9,7 @@ export default ({ throttleMs = 0 } = {}) => C =>
   withAnimationFrame(
     class extends Component {
       projectionRunning = true;
-      isMounted = false;
+      _isMounted = false;
       constructor(props) {
         super(props);
         this.state = {
@@ -18,7 +18,7 @@ export default ({ throttleMs = 0 } = {}) => C =>
         this.handleAnimation(props);
       }
       componentWillMount() {
-        this.isMounted = true;
+        this._isMounted = true;
       }
       handleAnimation({ projectionEnabled }) {
         if (projectionEnabled) {
@@ -36,7 +36,7 @@ export default ({ throttleMs = 0 } = {}) => C =>
       }
 
       componentWillUnmount() {
-        this.isMounted = false;
+        this._isMounted = false;
       }
 
       onAnimationFrame() {
@@ -48,7 +48,7 @@ export default ({ throttleMs = 0 } = {}) => C =>
         ).then(({ results }) => {
           //  console.log(results);
           const result = results.find(r => r.anchorId === planeId);
-          if (result && this.isMounted) {
+          if (result && this._isMounted) {
             this.setState({
               positionProjected: result.point,
             });

--- a/hocs/withProjectedPosition.js
+++ b/hocs/withProjectedPosition.js
@@ -45,20 +45,27 @@ export default ({ throttleMs = 33 } = {}) => C =>
       }
 
       onAnimationFrame() {
-        const { x, y, planeId } = this.props.projectPosition || {};
+        const { x, y, planeId, plane } = this.props.projectPosition || {};
 
-        ARKitManager.hitTestPlanes(
-          { x, y },
-          ARKitManager.ARHitTestResultType.ExistingPlane,
-        ).then(({ results }) => {
-          //  console.log(results);
-          const result = results.find(r => r.anchorId === planeId);
-          if (result && this._isMounted) {
-            this.setState({
-              positionProjected: roundPoint(result.point, 3),
-            });
-          }
-        });
+        if (planeId) {
+          ARKitManager.hitTestPlanes(
+            { x, y },
+            ARKitManager.ARHitTestResultType.ExistingPlane,
+          ).then(({ results }) => {
+            //  console.log(results);
+            const result = results.find(r => r.anchorId === planeId);
+            if (result && this._isMounted) {
+              this.setState({
+                positionProjected: roundPoint(result.point, 3),
+              });
+            }
+          });
+        } else if (plane) {
+          const { normal = { x: 0, y: 1, z: 0 }, position } = plane;
+          ARKitManager.getCamera().then(camera => {
+            console.log(camera);
+          });
+        }
       }
 
       render() {

--- a/hocs/withProjectedPosition.js
+++ b/hocs/withProjectedPosition.js
@@ -1,0 +1,62 @@
+import React, { Component } from 'react';
+import withAnimationFrame from 'react-animation-frame';
+
+import { NativeModules } from 'react-native';
+
+const ARKitManager = NativeModules.ARKitManager;
+
+export default ({ throttleMs = 0 } = {}) => C =>
+  withAnimationFrame(
+    class extends Component {
+      projectionRunning = true;
+      constructor(props) {
+        super(props);
+        this.state = {
+          positionProjected: props.position || { x: 0, y: 0, z: 0 },
+        };
+        this.handleAnimation(props);
+      }
+      handleAnimation({ projectionEnabled }) {
+        if (projectionEnabled) {
+          if (!this.projectionRunning) {
+            this.projectionRunning = true;
+            this.props.startAnimation();
+          }
+        } else if (this.projectionRunning) {
+          this.projectionRunning = false;
+          this.props.endAnimation();
+        }
+      }
+      componentWillUpdate({ projectionEnabled = true }) {
+        this.handleAnimation({ projectionEnabled });
+      }
+
+      onAnimationFrame() {
+        const { x, y, planeId } = this.props.projectPosition || {};
+
+        ARKitManager.hitTestPlanes(
+          { x, y },
+          ARKitManager.ARHitTestResultType.ExistingPlane,
+        ).then(({ results }) => {
+          //  console.log(results);
+          const result = results.find(r => r.anchorId === planeId);
+          if (result) {
+            this.setState({
+              positionProjected: result.point,
+            });
+          }
+        });
+      }
+
+      render() {
+        return (
+          <C
+            onProjectedPosition={this.onProjectedPosition}
+            positionProjected={this.state.positionProjected}
+            {...this.props}
+          />
+        );
+      }
+    },
+    throttleMs,
+  );

--- a/hocs/withProjectedPosition.js
+++ b/hocs/withProjectedPosition.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import withAnimationFrame from 'react-animation-frame';
+import withAnimationFrame from '@panter/react-animation-frame';
 
 import { NativeModules } from 'react-native';
 

--- a/hocs/withProjectedPosition.js
+++ b/hocs/withProjectedPosition.js
@@ -1,11 +1,16 @@
 import React, { Component } from 'react';
 import withAnimationFrame from '@panter/react-animation-frame';
-
+import { round } from 'lodash';
 import { NativeModules } from 'react-native';
 
 const ARKitManager = NativeModules.ARKitManager;
 
-export default ({ throttleMs = 0 } = {}) => C =>
+const roundPoint = ({ x, y, z }, precision) => ({
+  x: round(x, precision),
+  y: round(y, precision),
+  z: round(z, precision),
+});
+export default ({ throttleMs = 33 } = {}) => C =>
   withAnimationFrame(
     class extends Component {
       projectionRunning = true;
@@ -50,7 +55,7 @@ export default ({ throttleMs = 0 } = {}) => C =>
           const result = results.find(r => r.anchorId === planeId);
           if (result && this._isMounted) {
             this.setState({
-              positionProjected: result.point,
+              positionProjected: roundPoint(result.point, 3),
             });
           }
         });

--- a/hocs/withProjectedPosition.js
+++ b/hocs/withProjectedPosition.js
@@ -9,12 +9,16 @@ export default ({ throttleMs = 0 } = {}) => C =>
   withAnimationFrame(
     class extends Component {
       projectionRunning = true;
+      isMounted = false;
       constructor(props) {
         super(props);
         this.state = {
           positionProjected: props.position || { x: 0, y: 0, z: 0 },
         };
         this.handleAnimation(props);
+      }
+      componentWillMount() {
+        this.isMounted = true;
       }
       handleAnimation({ projectionEnabled }) {
         if (projectionEnabled) {
@@ -31,6 +35,10 @@ export default ({ throttleMs = 0 } = {}) => C =>
         this.handleAnimation({ projectionEnabled });
       }
 
+      componentWillUnmount() {
+        this.isMounted = false;
+      }
+
       onAnimationFrame() {
         const { x, y, planeId } = this.props.projectPosition || {};
 
@@ -40,7 +48,7 @@ export default ({ throttleMs = 0 } = {}) => C =>
         ).then(({ results }) => {
           //  console.log(results);
           const result = results.find(r => r.anchorId === planeId);
-          if (result) {
+          if (result && this.isMounted) {
             this.setState({
               positionProjected: result.point,
             });

--- a/hocs/withProjectedPosition.js
+++ b/hocs/withProjectedPosition.js
@@ -72,7 +72,7 @@ export default ({ throttleMs = 33 } = {}) => C =>
           ).then(({ results }) => {
             const result = isFunction(plane)
               ? plane(results)
-              : results.find(r => r.anchorId === plane);
+              : results.find(r => r.id === plane);
             this.onResult(result);
           });
         } else if (node) {

--- a/index.js
+++ b/index.js
@@ -5,23 +5,23 @@
 //  Copyright © 2017 HippoAR. All rights reserved.
 //
 
-import ARKit from './ARKit';
-import DeviceMotion from './DeviceMotion';
-
 import ARBox from './components/ARBox';
-import ARSphere from './components/ARSphere';
-import ARCylinder from './components/ARCylinder';
-import ARCone from './components/ARCone';
-import ARPyramid from './components/ARPyramid';
-import ARTube from './components/ARTube';
-import ARTorus from './components/ARTorus';
 import ARCapsule from './components/ARCapsule';
-import ARPlane from './components/ARPlane';
-import ARText from './components/ARText';
-import ARModel from './components/ARModel';
-import ARSprite from './components/ARSprite';
+import ARCone from './components/ARCone';
+import ARCylinder from './components/ARCylinder';
 import ARGroup from './components/ARGroup';
+import ARKit from './ARKit';
+import ARModel from './components/ARModel';
+import ARPlane from './components/ARPlane';
+import ARPyramid from './components/ARPyramid';
 import ARShape from './components/ARShape';
+import ARSphere from './components/ARSphere';
+import ARSprite from './components/ARSprite';
+import ARText from './components/ARText';
+import ARTorus from './components/ARTorus';
+import ARTube from './components/ARTube';
+import DeviceMotion from './DeviceMotion';
+import withProjectedPosition from './hocs/withProjectedPosition';
 
 ARKit.Box = ARBox;
 ARKit.Sphere = ARSphere;
@@ -52,5 +52,6 @@ module.exports = {
   ARPlane,
   ARText,
   ARModel,
-  ARGroup
+  ARGroup,
+  withProjectedPosition,
 };

--- a/ios/RCTARKit.m
+++ b/ios/RCTARKit.m
@@ -271,8 +271,10 @@ static NSMutableArray * mapHitResults(NSArray<ARHitTestResult *> *results) {
     NSMutableArray *resultsMapped = [NSMutableArray arrayWithCapacity:[results count]];
     [results enumerateObjectsUsingBlock:^(id obj, NSUInteger index, BOOL *stop) {
         ARHitTestResult *result = (ARHitTestResult *) obj;
+     
         [resultsMapped addObject:(@{
                                     @"distance": @(result.distance),
+                                    @"anchorId": result.anchor.identifier.UUIDString,
                                     @"point": @{
                                             @"x": @(result.worldTransform.columns[3].x),
                                             @"y": @(result.worldTransform.columns[3].y),

--- a/ios/RCTARKit.m
+++ b/ios/RCTARKit.m
@@ -41,7 +41,7 @@ void dispatch_once_on_main_thread(dispatch_once_t *predicate,
 + (instancetype)sharedInstance {
     static RCTARKit *instance = nil;
     static dispatch_once_t onceToken;
-    
+
     dispatch_once_on_main_thread(&onceToken, ^{
         if (instance == nil) {
             ARSCNView *arView = [[ARSCNView alloc] init];
@@ -54,30 +54,30 @@ void dispatch_once_on_main_thread(dispatch_once_t *predicate,
 - (instancetype)initWithARView:(ARSCNView *)arView {
     if ((self = [super init])) {
         self.arView = arView;
-        
+
         // delegates
         arView.delegate = self;
         arView.session.delegate = self;
-        
+
         UITapGestureRecognizer *tapGestureRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleTapFrom:)];
         tapGestureRecognizer.numberOfTapsRequired = 1;
         [self.arView addGestureRecognizer:tapGestureRecognizer];
-        
+
         self.touchDelegates = [NSMutableArray array];
         self.rendererDelegates = [NSMutableArray array];
         self.sessionDelegates = [NSMutableArray array];
-        
+
         // nodeManager
         self.nodeManager = [RCTARKitNodes sharedInstance];
         self.nodeManager.arView = arView;
         [self.sessionDelegates addObject:self.nodeManager];
-        
+
         // configuration(s)
         arView.autoenablesDefaultLighting = YES;
         arView.scene.rootNode.name = @"root";
-        
+
         self.planes = [NSMutableDictionary new];
-        
+
         // start ARKit
         [self addSubview:arView];
         [self resume];
@@ -197,7 +197,7 @@ static NSDictionary * vector4ToJson(const SCNVector4 v) {
 
 - (float)getCameraDistanceToPoint:(SCNVector3)point {
     return [self.nodeManager getCameraDistanceToPoint:point];
-    
+
 }
 
 
@@ -208,12 +208,12 @@ static NSDictionary * vector4ToJson(const SCNVector4 v) {
     if (_configuration) {
         return _configuration;
     }
-    
+
     if (!ARWorldTrackingConfiguration.isSupported) {}
-    
+
     _configuration = [ARWorldTrackingConfiguration new];
     _configuration.planeDetection = ARPlaneDetectionHorizontal;
-    
+
     return _configuration;
 }
 
@@ -222,7 +222,7 @@ static NSDictionary * vector4ToJson(const SCNVector4 v) {
 #pragma mark - snapshot methods
 
 - (void)hitTestSceneObjects:(const CGPoint)tapPoint resolve:(RCTARKitResolve)resolve reject:(RCTARKitReject)reject {
-    
+
     resolve([self.nodeManager getSceneObjectsHitResult:tapPoint]);
 }
 
@@ -239,14 +239,14 @@ static NSDictionary * vector4ToJson(const SCNVector4 v) {
 - (UIImage *)getSnaphsotCamera {
     CVPixelBufferRef pixelBuffer = self.arView.session.currentFrame.capturedImage;
     CIImage *ciImage = [CIImage imageWithCVPixelBuffer:pixelBuffer];
-    
+
     CIContext *temporaryContext = [CIContext contextWithOptions:nil];
     CGImageRef videoImage = [temporaryContext
                              createCGImage:ciImage
                              fromRect:CGRectMake(0, 0,
                                                  CVPixelBufferGetWidth(pixelBuffer),
                                                  CVPixelBufferGetHeight(pixelBuffer))];
-    
+
     UIImage *image = [UIImage imageWithCGImage:videoImage scale: 1.0 orientation:UIImageOrientationRight];
     CGImageRelease(videoImage);
     return image;
@@ -259,7 +259,7 @@ static NSDictionary * vector4ToJson(const SCNVector4 v) {
 #pragma mark - plane hit detection
 
 - (void)hitTestPlane:(const CGPoint)tapPoint types:(ARHitTestResultType)types resolve:(RCTARKitResolve)resolve reject:(RCTARKitReject)reject {
-    
+
     resolve([self getPlaneHitResult:tapPoint types:types]);
 }
 
@@ -267,16 +267,16 @@ static NSMutableArray * mapHitResults(NSArray<ARHitTestResult *> *results) {
     NSMutableArray *resultsMapped = [NSMutableArray arrayWithCapacity:[results count]];
     [results enumerateObjectsUsingBlock:^(id obj, NSUInteger index, BOOL *stop) {
         ARHitTestResult *result = (ARHitTestResult *) obj;
-     
+
         [resultsMapped addObject:(@{
                                     @"distance": @(result.distance),
-                                    @"anchorId": result.anchor.identifier.UUIDString,
+                                    @"id": result.anchor.identifier.UUIDString,
                                     @"point": @{
                                             @"x": @(result.worldTransform.columns[3].x),
                                             @"y": @(result.worldTransform.columns[3].y),
                                             @"z": @(result.worldTransform.columns[3].z)
                                             }
-                                    
+
                                     } )];
     }];
     return resultsMapped;
@@ -313,7 +313,7 @@ static NSDictionary * getPlaneHitResult(NSMutableArray *resultsMapped, const CGP
         NSDictionary * planeHitResult = [self getPlaneHitResult:tapPoint types:ARHitTestResultTypeExistingPlaneUsingExtent];
         self.onTapOnPlaneUsingExtent(planeHitResult);
     }
-    
+
     if(self.onTapOnPlaneNoExtent) {
         // Take the screen space tap coordinates and pass them to the hitTest method on the ARSCNView instance
         NSDictionary * planeHitResult = [self getPlaneHitResult:tapPoint types:ARHitTestResultTypeExistingPlane];
@@ -346,13 +346,13 @@ static NSDictionary * getPlaneHitResult(NSMutableArray *resultsMapped, const CGP
     if (![anchor isKindOfClass:[ARPlaneAnchor class]]) {
         return;
     }
-    
+
     SCNNode *parent = [node parentNode];
     NSLog(@"plane detected");
     //    NSLog(@"%f %f %f", parent.position.x, parent.position.y, parent.position.z);
-    
+
     ARPlaneAnchor *planeAnchor = (ARPlaneAnchor *)anchor;
-    
+
     //    NSLog(@"%@", @{
     //            @"id": planeAnchor.identifier.UUIDString,
     //            @"alignment": @(planeAnchor.alignment),
@@ -361,7 +361,7 @@ static NSDictionary * getPlaneHitResult(NSMutableArray *resultsMapped, const CGP
     //            @"extent": @{ @"x": @(planeAnchor.extent.x), @"y": @(planeAnchor.extent.y), @"z": @(planeAnchor.extent.z) },
     //            @"camera": @{ @"x": @(self.cameraOrigin.position.x), @"y": @(self.cameraOrigin.position.y), @"z": @(self.cameraOrigin.position.z) }
     //            });
-    
+
     if (self.onPlaneDetected) {
         self.onPlaneDetected(@{
                                @"id": planeAnchor.identifier.UUIDString,
@@ -372,7 +372,7 @@ static NSDictionary * getPlaneHitResult(NSMutableArray *resultsMapped, const CGP
                                //                               @"camera": @{ @"x": @(self.cameraOrigin.position.x), @"y": @(self.cameraOrigin.position.y), @"z": @(self.cameraOrigin.position.z) }
                                });
     }
-    
+
     //Plane *plane = [[Plane alloc] initWithAnchor: (ARPlaneAnchor *)anchor isHidden: NO];
     //[self.planes setObject:plane forKey:anchor.identifier];
     //[node addChildNode:plane];
@@ -383,13 +383,13 @@ static NSDictionary * getPlaneHitResult(NSMutableArray *resultsMapped, const CGP
 
 - (void)renderer:(id <SCNSceneRenderer>)renderer didUpdateNode:(SCNNode *)node forAnchor:(ARAnchor *)anchor {
     ARPlaneAnchor *planeAnchor = (ARPlaneAnchor *)anchor;
-    
+
     SCNNode *parent = [node parentNode];
     //    NSLog(@"%@", parent.name);
     //    NSLog(@"%f %f %f", node.position.x, node.position.y, node.position.z);
     //    NSLog(@"%f %f %f %f", node.rotation.x, node.rotation.y, node.rotation.z, node.rotation.w);
-    
-    
+
+
     //    NSLog(@"%@", @{
     //                   @"id": planeAnchor.identifier.UUIDString,
     //                   @"alignment": @(planeAnchor.alignment),
@@ -398,7 +398,7 @@ static NSDictionary * getPlaneHitResult(NSMutableArray *resultsMapped, const CGP
     //                   @"extent": @{ @"x": @(planeAnchor.extent.x), @"y": @(planeAnchor.extent.y), @"z": @(planeAnchor.extent.z) },
     //                   @"camera": @{ @"x": @(self.cameraOrigin.position.x), @"y": @(self.cameraOrigin.position.y), @"z": @(self.cameraOrigin.position.z) }
     //                   });
-    
+
     if (self.onPlaneUpdate) {
         self.onPlaneUpdate(@{
                              @"id": planeAnchor.identifier.UUIDString,
@@ -409,12 +409,12 @@ static NSDictionary * getPlaneHitResult(NSMutableArray *resultsMapped, const CGP
                              //                             @"camera": @{ @"x": @(self.cameraOrigin.position.x), @"y": @(self.cameraOrigin.position.y), @"z": @(self.cameraOrigin.position.z) }
                              });
     }
-    
+
     Plane *plane = [self.planes objectForKey:anchor.identifier];
     if (plane == nil) {
         return;
     }
-    
+
     [plane update:(ARPlaneAnchor *)anchor];
 }
 
@@ -436,20 +436,20 @@ static NSDictionary * getPlaneHitResult(NSMutableArray *resultsMapped, const CGP
         NSMutableArray * featurePoints = [NSMutableArray array];
         for (int i = 0; i < frame.rawFeaturePoints.count; i++) {
             vector_float3 point = frame.rawFeaturePoints.points[i];
-            
+
             NSString * pointId = [NSString stringWithFormat:@"featurepoint_%lld",frame.rawFeaturePoints.identifiers[i]];
-            
+
             [featurePoints addObject:@{
                                        @"x": @(point[0]),
                                        @"y": @(point[1]),
                                        @"z": @(point[2]),
                                        @"id":pointId,
                                        }];
-            
+
         }
         dispatch_async(dispatch_get_main_queue(), ^{
-            
-            
+
+
             if(self.onFeaturesDetected) {
                 self.onFeaturesDetected(@{
                                           @"featurePoints":featurePoints

--- a/ios/RCTARKit.m
+++ b/ios/RCTARKit.m
@@ -187,21 +187,10 @@ static NSDictionary * vector4ToJson(const SCNVector4 v) {
     return [self.arView projectPoint:point];
 }
 
-static float getDistance(const SCNVector3 pointA, const SCNVector3 pointB) {
-    float xd = pointB.x - pointA.x;
-    float yd = pointB.y - pointA.y;
-    float zd = pointB.z - pointA.z;
-    float distance = sqrt(xd * xd + yd * yd + zd * zd);
-    
-    if (distance < 0){
-        return (distance * -1);
-    } else {
-        return (distance);
-    }
-}
+
 
 - (float)getCameraDistanceToPoint:(SCNVector3)point {
-    return getDistance(self.nodeManager.cameraOrigin.position, point);
+    return [self.nodeManager getCameraDistanceToPoint:point];
     
 }
 

--- a/ios/RCTARKit.xcodeproj/project.pbxproj
+++ b/ios/RCTARKit.xcodeproj/project.pbxproj
@@ -292,6 +292,7 @@
 					../../../ios/Pods/Headers/Public/,
 					../../../ios/Pods/Headers/Public/React,
 					"$(SRCROOT)/../../_PocketSVG/**",
+					"../node_modules/_PocketSVG/**",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
@@ -314,6 +315,7 @@
 					../../../ios/Pods/Headers/Public/,
 					../../../ios/Pods/Headers/Public/React,
 					"$(SRCROOT)/../../_PocketSVG/**",
+					"../node_modules/_PocketSVG/**",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LIBRARY_SEARCH_PATHS = "$(inherited)";

--- a/ios/RCTARKitNodes.h
+++ b/ios/RCTARKitNodes.h
@@ -37,6 +37,7 @@ typedef NS_OPTIONS(NSUInteger, RFReferenceFrame) {
 
 - (void)addNodeToScene:(SCNNode *)node inReferenceFrame:(NSString *)referenceFrame;
 - (void)updateNode:(NSString *)key properties:(NSDictionary *) properties;
+- (float)getCameraDistanceToPoint:(SCNVector3)point;
 - (void)registerNode:(SCNNode *)node forKey:(NSString *)key;
 - (SCNNode *)nodeForKey:(NSString *)key;
 - (void)removeNodeForKey:(NSString *)key;

--- a/ios/RCTARKitNodes.m
+++ b/ios/RCTARKitNodes.m
@@ -31,7 +31,7 @@ CGFloat focDistance = 0.2f;
 + (instancetype)sharedInstance {
     static RCTARKitNodes *instance = nil;
     static dispatch_once_t onceToken;
-    
+
     dispatch_once(&onceToken, ^{
         if (instance == nil) {
             instance = [[self alloc] init];
@@ -45,15 +45,15 @@ CGFloat focDistance = 0.2f;
         // local reference frame origin
         self.localOrigin = [[SCNNode alloc] init];
         self.localOrigin.name = @"localOrigin";
-        
+
         // camera reference frame origin
         self.cameraOrigin = [[SCNNode alloc] init];
         self.cameraOrigin.name = @"cameraOrigin";
-        
+
         // front-of-camera frame origin
         self.frontOfCamera = [[SCNNode alloc] init];
         self.frontOfCamera.name = @"frontOfCamera";
-        
+
         // init cahces
         self.nodes = [NSMutableDictionary new];
     }
@@ -65,7 +65,7 @@ CGFloat focDistance = 0.2f;
     _arView = arView;
     self.rootNode = arView.scene.rootNode;
     self.rootNode.name = @"root";
-    
+
     [self.rootNode addChildNode:self.localOrigin];
     [self.rootNode addChildNode:self.cameraOrigin];
     [self.rootNode addChildNode:self.frontOfCamera];
@@ -93,21 +93,21 @@ CGFloat focDistance = 0.2f;
 - (void)clear {
     // clear scene
     NSArray *keys = [self.nodes allKeys];
-    
+
     for (id key in keys) {
         id node = [self.nodes objectForKey:key];
         if (node) {
             [node removeFromParentNode];
         }
-        
+
     }
     [self.nodes removeAllObjects];
 }
 
 - (void)addNodeToLocalFrame:(SCNNode *)node {
     node.referenceFrame = RFReferenceFrameLocal;
-    
-    NSLog(@"[RCTARKitNodes] Add model %@ to Local frame at (%.2f, %.2f, %.2f)", node.name, node.position.x, node.position.y, node.position.z);
+
+    //NSLog(@"[RCTARKitNodes] Add node %@ to Local frame at (%.2f, %.2f, %.2f)", node.name, node.position.x, node.position.y, node.position.z);
 
     [self registerNode:node forKey:node.name];
     [self.localOrigin addChildNode:node];
@@ -115,16 +115,16 @@ CGFloat focDistance = 0.2f;
 
 - (void)addNodeToCameraFrame:(SCNNode *)node {
     node.referenceFrame = RFReferenceFrameCamera;
-    
-    NSLog(@"[RCTARKitNodes] Add model %@ to Camera frame at (%.2f, %.2f, %.2f)", node.name, node.position.x, node.position.y, node.position.z);
+
+    //NSLog(@"[RCTARKitNodes] Add node %@ to Camera frame at (%.2f, %.2f, %.2f)", node.name, node.position.x, node.position.y, node.position.z);
     [self registerNode:node forKey:node.name];
     [self.cameraOrigin addChildNode:node];
 }
 
 - (void)addNodeToFrontOfCameraFrame:(SCNNode *)node {
     node.referenceFrame = RFReferenceFrameFrontOfCamera;
-    
-    NSLog(@"[RCTARKitNodes] Add model %@ to FrontOfCamera frame at (%.2f, %.2f, %.2f)", node.name, node.position.x, node.position.y, node.position.z);
+
+    //NSLog(@"[RCTARKitNodes] Add node %@ to FrontOfCamera frame at (%.2f, %.2f, %.2f)", node.name, node.position.x, node.position.y, node.position.z);
     [self registerNode:node forKey:node.name];
     [self.frontOfCamera addChildNode:node];
 }
@@ -153,14 +153,14 @@ static NSDictionary * getSceneObjectHitResult(NSMutableArray *resultsMapped, con
 
 
 - (NSMutableArray *) mapHitResultsWithSceneResults: (NSArray<SCNHitTestResult *> *)results {
-    
+
     NSMutableArray *resultsMapped = [NSMutableArray arrayWithCapacity:[results count]];
     [results enumerateObjectsUsingBlock:^(id obj, NSUInteger index, BOOL *stop) {
         SCNHitTestResult *result = (SCNHitTestResult *) obj;
         SCNNode * node = result.node;
         NSArray *keys = [self.nodes allKeysForObject: node];
         if([keys count]) {
-            
+
             NSString * firstKey = [keys firstObject];
             [resultsMapped addObject:(@{
                                         @"id": firstKey
@@ -171,10 +171,10 @@ static NSDictionary * getSceneObjectHitResult(NSMutableArray *resultsMapped, con
             NSLog(@"all nodes %@", self.nodes);
             NSLog(@"origin %@", self.localOrigin);
         }
-        
+
     }];
     return resultsMapped;
-    
+
 }
 
 
@@ -205,7 +205,7 @@ static NSDictionary * getSceneObjectHitResult(NSMutableArray *resultsMapped, con
     if(node) {
         [RCTConvert setNodeProperties:node properties:properties];
     }
-    
+
 }
 
 
@@ -218,7 +218,7 @@ static NSDictionary * getSceneObjectHitResult(NSMutableArray *resultsMapped, con
     self.cameraOrigin.eulerAngles = SCNVector3Make(0, atan2f(z.x, z.z), 0);
     self.frontOfCamera.position = SCNVector3Make(pos.x - focDistance * z.x, pos.y  - focDistance * z.y, pos.z - focDistance * z.z);
     self.frontOfCamera.eulerAngles = self.cameraOrigin.eulerAngles;
-    
+
 }
 
 @end

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "lodash": "^4.17.4",
     "prop-types": "^15.5.7",
     "react": "16.0.0-alpha.12",
-    "@panter/react-animation-frame": "^0.3.6"
+    "@panter/react-animation-frame": "^0.3.7"
   },
   "devDependencies": {
     "babel-eslint": "^7.2.3",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "lodash": "^4.17.4",
     "prop-types": "^15.5.7",
     "react": "16.0.0-alpha.12",
-    "react-animation-frame": "^0.3.5"
+    "react-animation-frame":
+      "https://github.com/panter/react-animation-frame#7946ab8f7ffedc7f0bffc33ba37c38732df60e16"
   },
   "devDependencies": {
     "babel-eslint": "^7.2.3",

--- a/package.json
+++ b/package.json
@@ -9,18 +9,24 @@
   "author": "Zehao Li <qft.gtr@gmail.com>",
   "license": "MIT",
   "homepage": "https://github.com/HippoAR/react-native-arkit",
-  "keywords": ["react-native", "react", "native", "ARKit", "AR"],
+  "keywords": [
+    "react-native",
+    "react",
+    "native",
+    "ARKit",
+    "AR"
+  ],
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
+    "@panter/react-animation-frame": "^0.3.7",
     "_PocketSVG": "https://github.com/pocketsvg/PocketSVG",
     "fast-deep-equal": "^1.0.0",
     "lodash": "^4.17.4",
     "prop-types": "^15.5.7",
-    "react": "16.0.0-alpha.12",
-    "@panter/react-animation-frame": "^0.3.7"
+    "react": "16.0.0-alpha.12"
   },
   "devDependencies": {
     "babel-eslint": "^7.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"@panter/react-animation-frame@^0.3.6":
+"@panter/react-animation-frame@^0.3.7":
   version "0.3.7"
   resolved "https://registry.yarnpkg.com/@panter/react-animation-frame/-/react-animation-frame-0.3.7.tgz#31a0d7683e4a8d2e1b29ff512cad36513bd43d00"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,12 @@
 # yarn lockfile v1
 
 
+"@panter/react-animation-frame@^0.3.6":
+  version "0.3.7"
+  resolved "https://registry.yarnpkg.com/@panter/react-animation-frame/-/react-animation-frame-0.3.7.tgz#31a0d7683e4a8d2e1b29ff512cad36513bd43d00"
+  dependencies:
+    react "15.4.2"
+
 "_PocketSVG@https://github.com/pocketsvg/PocketSVG":
   version "0.0.0"
   resolved "https://github.com/pocketsvg/PocketSVG#e6d84ddeb11f99c4420e354ebb9fd34db2cf507a"
@@ -1420,12 +1426,6 @@ prop-types@^15.5.10, prop-types@^15.5.6, prop-types@^15.5.7:
 pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
-
-react-animation-frame@^0.3.5:
-  version "0.3.5"
-  resolved "https://registry.yarnpkg.com/react-animation-frame/-/react-animation-frame-0.3.5.tgz#6afe77e8c8b8774c56183598ba40c6de4dce4588"
-  dependencies:
-    react "15.4.2"
 
 react-deep-force-update@^1.0.0:
   version "1.1.1"


### PR DESCRIPTION
adds new hoc `withProjectedPosition`

this hoc allows you to create 3D components where the position is always at the same point relative to the screen/camera, but sticks to a plane or object.

Think about a 3D cursor that can be moved across your table or a 3D cursor on a wall.

You can use the hoc like this:

```
const Cursor3D = withProjectedPosition()(({positionProjected, projectionResult}) => {
  if(!projectionResult) {
    // nothing has been hit, don't render it
    return null;
  }
  return (
    <ARKit.Sphere
      position={positionProjected}
      shape={{
        radius: 0.1
        }}
    />
  )
})

```

Now you can your 3D cursor like this:

##### Attach to a given detected horizontal plane

Given you have detected a plane with onPlaneDetected, you can make the cursor stick to that plane:

```
<Cursor3D projectPosition={{
  x: windowWidth / 2,
  y: windowHeight / 2,
  plane: "my-planeId"
  }}
/>

```

If you don't have the id, but want to place the cursor on a certain plane (e.g. the first or last one), pass a function for plane. This function will get all hit-results and you can return the one you need:

```
<Cursor3D projectPosition={{
  x: windowWidth / 2,
  y: windowHeight / 2,
  plane: (results) => results.length > 0 ? results[0] : null
  }}
/>

```

It uses https://developer.apple.com/documentation/arkit/arframe/2875718-hittest with some default options. Please file an issue or send a PR if you need more control over the options here!

##### Attach to a given 3D object

You can attach the cursor on a 3D object, e.g. a non-horizontal-plane or similar:

Given there is some 3D object on your scene with `id="my-nodeId"`

```
<Cursor3D projectPosition={{
  x: windowWidth / 2,
  y: windowHeight / 2,
  node: "my-nodeId"
  }}
/>
```

Like with planes, you can select the node with a function.

E.gl you have several "walls" with ids "wall_1", "wall_2", etc.

```
<Cursor3D projectPosition={{
  x: windowWidth / 2,
  y: windowHeight / 2,
  node: results => results.find(r => r.id.startsWith('wall_')),
  }}
/>
```


It uses https://developer.apple.com/documentation/scenekit/scnscenerenderer/1522929-hittest with some default options. Please file an issue or send a PR if you need more control over the options here!

