### PR TITLE
Add `worldAlignment` prop to `ARKit` component

### DIFF
--- a/ARKit.js
+++ b/ARKit.js
@@ -176,6 +176,7 @@ ARKit.propTypes = {
   debug: PropTypes.bool,
   planeDetection: PropTypes.bool,
   lightEstimation: PropTypes.bool,
+  worldAlignment: PropTypes.number,
   onPlaneDetected: PropTypes.func,
   onFeaturesDetected: PropTypes.func,
   onPlaneUpdate: PropTypes.func,

--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ AppRegistry.registerComponent('ReactNativeARKit', () => ReactNativeARKit);
 | `debug` | `Boolean` | `false` | Debug mode will show the 3D axis and feature points detected.
 | `planeDetection` | `Boolean` | `false` | ARKit plane detection.
 | `lightEstimation` | `Boolean` | `false` | ARKit light estimation.
+| `worldAlignment` | `Enumeration` <br /> One of: `ARKit.ARWorldAlignment.Gravity`, `ARKit.ARWorldAlignment.GravityAndHeading`, `ARKit.ARWorldAlignment.Camera` (documentation [here](https://developer.apple.com/documentation/arkit/arworldalignment)) | `ARKit.ARWorldAlignment.Gravity` | **ARWorldAlignmentGravity** <br /> The coordinate system's y-axis is parallel to gravity, and its origin is the initial position of the device. **ARWorldAlignmentGravityAndHeading** <br /> The coordinate system's y-axis is parallel to gravity, its x- and z-axes are oriented to compass heading, and its origin is the initial position of the device. **ARWorldAlignmentCamera** <br /> The scene coordinate system is locked to match the orientation of the camera.|
 
 ##### Events
 

--- a/ios/RCTARKit.h
+++ b/ios/RCTARKit.h
@@ -36,6 +36,7 @@ typedef void (^RCTARKitReject)(NSString *code, NSString *message, NSError *error
 @property (nonatomic, assign) BOOL debug;
 @property (nonatomic, assign) BOOL planeDetection;
 @property (nonatomic, assign) BOOL lightEstimation;
+@property (nonatomic, assign) ARWorldAlignment worldAlignment;
 
 @property (nonatomic, copy) RCTBubblingEventBlock onPlaneDetected;
 @property (nonatomic, copy) RCTBubblingEventBlock onFeaturesDetected;

--- a/ios/RCTARKit.m
+++ b/ios/RCTARKit.m
@@ -160,6 +160,23 @@ void dispatch_once_on_main_thread(dispatch_once_t *predicate,
     [self resume];
 }
 
+- (ARWorldAlignment)worldAlignment {
+    ARConfiguration *configuration = self.session.configuration;
+    return configuration.worldAlignment;
+}
+
+- (void)setWorldAlignment:(ARWorldAlignment)worldAlignment {
+    ARConfiguration *configuration = self.configuration;
+    if (worldAlignment == ARWorldAlignmentGravityAndHeading) {
+        configuration.worldAlignment = ARWorldAlignmentGravityAndHeading;
+    } else if (worldAlignment == ARWorldAlignmentCamera) {
+        configuration.worldAlignment = ARWorldAlignmentCamera;
+    } else {
+        configuration.worldAlignment = ARWorldAlignmentGravity;
+    }
+    [self resume];
+}
+
 - (NSDictionary *)readCameraPosition {
     // deprecated
     SCNVector3 cameraPosition = self.nodeManager.cameraOrigin.position;

--- a/ios/RCTARKitManager.m
+++ b/ios/RCTARKitManager.m
@@ -57,6 +57,11 @@ RCT_EXPORT_MODULE()
                      @"Back": [@(SCNChamferModeBack) stringValue],
                      @"Front": [@(SCNChamferModeBack) stringValue],
                      
+                     },
+             @"ARWorldAlignment": @{
+                     @"Gravity": @(ARWorldAlignmentGravity),
+                     @"GravityAndHeading": @(ARWorldAlignmentGravityAndHeading),
+                     @"Camera": @(ARWorldAlignmentCamera),
                      }
              };
 }
@@ -64,6 +69,7 @@ RCT_EXPORT_MODULE()
 RCT_EXPORT_VIEW_PROPERTY(debug, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(planeDetection, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(lightEstimation, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(worldAlignment, NSInteger)
 
 RCT_EXPORT_VIEW_PROPERTY(onPlaneDetected, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onPlaneUpdate, RCTBubblingEventBlock)


### PR DESCRIPTION
This pull request adds the ability to customize the `ARWorldAlignment` property in the `ARKit` configuration.