### PR TITLE
Fix invalid prop readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ AppRegistry.registerComponent('ReactNativeARKit', () => ReactNativeARKit);
 |---|---|
 | `position` | `{ x, y, z }` |
 | `eulerAngles` | `{ x, y, z }` |
-| `shape` | `{ width, length }` |
+| `shape` | `{ width, height }` |
 | `material` | `{ diffuse, metalness, roughness, lightingModel }` |
 
 #### [`<ARKit.Text />`](https://developer.apple.com/documentation/scenekit/scntext)


### PR DESCRIPTION
Both SCNPlane and <ARKit.Plane> only accept a width and height (https://developer.apple.com/documentation/scenekit/scnplane)