### PR TITLE
WIP: fix dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,13 +14,17 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
+  "peerDependencies": {
+    "react-native": ">=0.46.0",
+    "react": "*",
+    "prop-types": "*"
+  },
   "dependencies": {
     "@panter/react-animation-frame": "^0.3.7",
     "_PocketSVG": "https://github.com/pocketsvg/PocketSVG",
     "fast-deep-equal": "^1.0.0",
     "lodash": "^4.17.4",
-    "prop-types": "^15.5.7",
-    "react": "16.0.0-alpha.12"
+    "prop-types": "^15.5.7"
   },
   "devDependencies": {
     "babel-eslint": "^7.2.3",
@@ -33,6 +37,8 @@
     "eslint-plugin-jsx-a11y": "^5.0.3",
     "eslint-plugin-prettier": "^2.1.1",
     "eslint-plugin-react": "^7.0.1",
-    "prettier": "^1.3.1"
+    "prettier": "^1.3.1",
+    "react": "16.0.0-alpha.12",
+    "prop-types": "^15.5.8"
   }
 }


### PR DESCRIPTION
- [x] use peer dependencies for react
- [ ] use cocoapods for pocketsvg

using cocoapods for react-native link libraries is possible since react-native 0.50, but i have not tried it out yet.

Should fix https://github.com/HippoAR/react-native-arkit/issues/103 and https://github.com/HippoAR/react-native-arkit/issues/104