### PR TITLE
allow to update most properties and therefore do transitions 

### DIFF
--- a/ARKit.js
+++ b/ARKit.js
@@ -199,4 +199,4 @@ ARKit.propTypes = {
 
 const RCTARKit = requireNativeComponent('RCTARKit', ARKit);
 
-module.exports = ARKit;
+export default ARKit;

--- a/DeviceMotion.js
+++ b/DeviceMotion.js
@@ -16,4 +16,4 @@ const DeviceMotion = {
   },
 };
 
-module.exports = DeviceMotion;
+export default DeviceMotion;

--- a/components/ARBox.js
+++ b/components/ARBox.js
@@ -20,4 +20,4 @@ const ARBox = createArComponent('addBox', {
   material,
 });
 
-module.exports = ARBox;
+export default ARBox;

--- a/components/ARCapsule.js
+++ b/components/ARCapsule.js
@@ -18,4 +18,4 @@ const ARCapsule = createArComponent('addCapsule', {
   material,
 });
 
-module.exports = ARCapsule;
+export default ARCapsule;

--- a/components/ARCone.js
+++ b/components/ARCone.js
@@ -19,4 +19,4 @@ const ARCone = createArComponent('addCone', {
   material,
 });
 
-module.exports = ARCone;
+export default ARCone;

--- a/components/ARCylinder.js
+++ b/components/ARCylinder.js
@@ -18,4 +18,4 @@ const ARCylinder = createArComponent('addCylinder', {
   material,
 });
 
-module.exports = ARCylinder;
+export default ARCylinder;

--- a/components/ARGroup.js
+++ b/components/ARGroup.js
@@ -7,4 +7,4 @@ const ARGroup = class extends Component {
   }
 };
 
-module.exports = ARGroup;
+export default ARGroup;

--- a/components/ARLight.js
+++ b/components/ARLight.js
@@ -25,4 +25,4 @@ const ARLight = createArComponent('addLight', {
   lightCategoryBitMask: categoryBitMask,
 });
 
-module.exports = ARLight;
+export default ARLight;

--- a/components/ARModel.js
+++ b/components/ARModel.js
@@ -25,6 +25,7 @@ const ARModel = createArComponent(
     }),
     material,
   },
+  ['model'],
 );
 
-module.exports = ARModel;
+export default ARModel;

--- a/components/ARPlane.js
+++ b/components/ARPlane.js
@@ -22,4 +22,4 @@ const ARPlane = createArComponent('addPlane', {
   material,
 });
 
-module.exports = ARPlane;
+export default ARPlane;

--- a/components/ARPyramid.js
+++ b/components/ARPyramid.js
@@ -19,4 +19,4 @@ const ARPyramid = createArComponent('addPyramid', {
   material,
 });
 
-module.exports = ARPyramid;
+export default ARPyramid;

--- a/components/ARShape.js
+++ b/components/ARShape.js
@@ -11,9 +11,9 @@ const ARShape = createArComponent('addShape', {
     chamferMode,
     chamferRadius: PropTypes.number,
     chamferProfilePathSvg: PropTypes.string,
-    chamferProfilePathFlatness: PropTypes.string,
+    chamferProfilePathFlatness: PropTypes.number,
   }),
   material,
 });
 
-module.exports = ARShape;
+export default ARShape;

--- a/components/ARSphere.js
+++ b/components/ARSphere.js
@@ -17,4 +17,4 @@ const ARSphere = createArComponent('addSphere', {
   material,
 });
 
-module.exports = ARSphere;
+export default ARSphere;

--- a/components/ARSprite.js
+++ b/components/ARSprite.js
@@ -48,4 +48,4 @@ ARSprite.propTypes = {
   position
 };
 
-module.exports = ARSprite;
+export default ARSprite;

--- a/components/ARText.js
+++ b/components/ARText.js
@@ -21,10 +21,11 @@ const ARText = createArComponent(
       // weight: PropTypes.string,
       size: PropTypes.number,
       depth: PropTypes.number,
-      chamfer: PropTypes.number,
+      chamfer: PropTypes.number
     }),
-    material,
+    material
   },
+  ['text', 'font']
 );
 
-module.exports = ARText;
+export default ARText;

--- a/components/ARTorus.js
+++ b/components/ARTorus.js
@@ -18,4 +18,4 @@ const ARTorus = createArComponent('addTorus', {
   material,
 });
 
-module.exports = ARTorus;
+export default ARTorus;

--- a/components/ARTube.js
+++ b/components/ARTube.js
@@ -19,4 +19,4 @@ const ARTube = createArComponent('addTube', {
   material,
 });
 
-module.exports = ARTube;
+export default ARTube;

--- a/components/lib/propTypes.js
+++ b/components/lib/propTypes.js
@@ -1,7 +1,6 @@
+import { NativeModules } from 'react-native';
 import { values } from 'lodash';
 import PropTypes from 'prop-types';
-
-import { NativeModules } from 'react-native';
 
 const ARKitManager = NativeModules.ARKitManager;
 

--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ ARKit.Group = ARGroup;
 ARKit.Shape = ARShape;
 ARKit.Light = ARLight;
 
-module.exports = {
+export {
   ARKit,
   DeviceMotion,
   ARBox,
@@ -57,5 +57,5 @@ module.exports = {
   ARModel,
   ARLight,
   ARGroup,
-  withProjectedPosition
+  withProjectedPosition,
 };

--- a/ios/RCTARKit.m
+++ b/ios/RCTARKit.m
@@ -239,7 +239,6 @@ static NSDictionary * vector4ToJson(const SCNVector4 v) {
     
     _configuration = [ARWorldTrackingConfiguration new];
     _configuration.planeDetection = ARPlaneDetectionHorizontal;
-  
     return _configuration;
 }
 

--- a/ios/RCTARKitNodes.h
+++ b/ios/RCTARKitNodes.h
@@ -36,7 +36,7 @@ typedef NS_OPTIONS(NSUInteger, RFReferenceFrame) {
 + (instancetype)sharedInstance;
 
 - (void)addNodeToScene:(SCNNode *)node inReferenceFrame:(NSString *)referenceFrame;
-- (void)updateNode:(NSString *)key properties:(NSDictionary *) properties;
+- (void)updateNode:(NSString *)nodeId properties:(NSDictionary *) properties;
 - (float)getCameraDistanceToPoint:(SCNVector3)point;
 - (void)registerNode:(SCNNode *)node forKey:(NSString *)key;
 - (SCNNode *)nodeForKey:(NSString *)key;

--- a/ios/RCTARKitNodes.m
+++ b/ios/RCTARKitNodes.m
@@ -234,14 +234,28 @@ static NSDictionary * getSceneObjectHitResult(NSMutableArray *resultsMapped, con
     }
 }
 
-- (void)updateNode:(NSString *)key properties:(NSDictionary *) properties {
-    SCNNode *node = [self.nodes objectForKey:key];
-    // only basic properties like position and rotation can currently be updated this way
+- (void)updateNode:(NSString *)nodeId properties:(NSDictionary *) properties {
+    SCNNode *node = [self.nodes objectForKey:nodeId];
     if(node) {
         [RCTConvert setNodeProperties:node properties:properties];
+        if(node.geometry && properties[@"shape"]) {
+              [RCTConvert setShapeProperties:node.geometry properties:properties[@"shape"]];
+        }
+        if(properties[@"material"]) {
+            for (id material in node.geometry.materials) {
+                [RCTConvert setMaterialProperties:material properties:properties[@"material"]];
+            }
+        }
+        if(node.light) {
+            [RCTConvert setLightProperties:node.light properties:properties];
+        }
+        
+        
     }
     
 }
+
+
 
 
 #pragma mark - RCTARKitSessionDelegate

--- a/ios/RCTConvert+ARKit.h
+++ b/ios/RCTConvert+ARKit.h
@@ -38,6 +38,8 @@
 
 + (void)setNodeProperties:(SCNNode *)node properties:(id)json;
 + (void)setMaterialProperties:(SCNMaterial *)material properties:(id)json;
++ (void)setShapeProperties:(SCNGeometry *)geometry properties:(id)json;
++ (void)setLightProperties:(SCNLight *)light properties:(id)json;
 
 @end
 

--- a/ios/components/ARGeosManager.m
+++ b/ios/components/ARGeosManager.m
@@ -18,6 +18,7 @@ RCT_EXPORT_METHOD(addBox:(SCNBox *)geometry node:(SCNNode *)node frame:(NSString
     [[RCTARKitNodes sharedInstance] addNodeToScene:node inReferenceFrame:frame];
 }
 
+
 RCT_EXPORT_METHOD(addSphere:(SCNSphere *)geometry node:(SCNNode *)node frame:(NSString *)frame) {
     node.geometry = geometry;
     [[RCTARKitNodes sharedInstance] addNodeToScene:node inReferenceFrame:frame];
@@ -70,17 +71,11 @@ RCT_EXPORT_METHOD(addLight:(SCNLight *)light node:(SCNNode *)node frame:(NSStrin
 
 
 RCT_EXPORT_METHOD(unmount:(NSString *)identifier) {
- 
-    
     [[RCTARKitNodes sharedInstance] removeNodeForKey:identifier];
-
-    
 }
 
 RCT_EXPORT_METHOD(updateNode:(NSString *)identifier properties:(NSDictionary *) properties) {
-
     [[RCTARKitNodes sharedInstance] updateNode:identifier properties:properties];
-
 }
 
 @end


### PR DESCRIPTION
This change prevents remounting of nodes in scenekit on most properties and therefore makes transitions work. 

it has some rough edges but at least allows transitioning on many shape properties like box width, height, cylinder lengths, etc.

it also allows to do transitions on light properties (like color, intensity, etc.) and some material properties, altough i don't know on which transitions work out-of-the-box

fixes https://github.com/HippoAR/react-native-arkit/issues/92