### PR TITLE
Allow auto-deployment with react-native-pod

### DIFF
--- a/ios/RCTARKit.xcodeproj/project.pbxproj
+++ b/ios/RCTARKit.xcodeproj/project.pbxproj
@@ -61,8 +61,6 @@
 		10FEF6121F774C9000EC21AE /* RCTARKitNodes.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RCTARKitNodes.m; sourceTree = "<group>"; };
 		10FEF6131F774C9000EC21AE /* RCTARKitDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RCTARKitDelegate.h; sourceTree = "<group>"; };
 		134814201AA4EA6300B7C361 /* libRCTARKit.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libRCTARKit.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		B14C36631F960C500047CB67 /* PocketSVG.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PocketSVG.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		B14C36651F960C6E0047CB67 /* PocketSVG.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PocketSVG.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B3E7B5881CC2AC0600A0062D /* RCTARKit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTARKit.h; sourceTree = "<group>"; };
 		B3E7B5891CC2AC0600A0062D /* RCTARKit.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTARKit.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -119,17 +117,7 @@
 				105F124C1F7C0718006D4BA3 /* RCTConvert+ARKit.h */,
 				105F124D1F7C0718006D4BA3 /* RCTConvert+ARKit.m */,
 				134814211AA4EA7D00B7C361 /* Products */,
-				B13FF7601F94F72400A6C92B /* Frameworks */,
 			);
-			sourceTree = "<group>";
-		};
-		B13FF7601F94F72400A6C92B /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				B14C36651F960C6E0047CB67 /* PocketSVG.framework */,
-				B14C36631F960C500047CB67 /* PocketSVG.framework */,
-			);
-			name = Frameworks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -291,8 +279,7 @@
 					"$(SRCROOT)/../../react-native-arcl/ios",
 					../../../ios/Pods/Headers/Public/,
 					../../../ios/Pods/Headers/Public/React,
-					"$(SRCROOT)/../../_PocketSVG/**",
-					"../node_modules/_PocketSVG/**",
+					"$(SRCROOT)/../../../ios/Pods/PocketSVG/**",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
@@ -314,8 +301,7 @@
 					"$(SRCROOT)/../../react-native-arcl/ios",
 					../../../ios/Pods/Headers/Public/,
 					../../../ios/Pods/Headers/Public/React,
-					"$(SRCROOT)/../../_PocketSVG/**",
-					"../node_modules/_PocketSVG/**",
+					"$(SRCROOT)/../../../ios/Pods/PocketSVG/**",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LIBRARY_SEARCH_PATHS = "$(inherited)";

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   },
   "dependencies": {
     "@panter/react-animation-frame": "^0.3.7",
-    "_PocketSVG": "https://github.com/pocketsvg/PocketSVG",
     "fast-deep-equal": "^1.0.0",
     "lodash": "^4.17.4",
     "prop-types": "^15.5.7"
@@ -40,5 +39,8 @@
     "prettier": "^1.3.1",
     "react": "16.0.0-alpha.12",
     "prop-types": "^15.5.8"
+  }, 
+  "pods": {
+    "PocketSVG": "*"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,15 +9,22 @@
   "author": "Zehao Li <qft.gtr@gmail.com>",
   "license": "MIT",
   "homepage": "https://github.com/HippoAR/react-native-arkit",
-  "keywords": ["react-native", "react", "native", "ARKit", "AR"],
+  "keywords": [
+    "react-native",
+    "react",
+    "native",
+    "ARKit",
+    "AR"
+  ],
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "peerDependencies": {
-    "react-native": ">=0.46.0",
+    "prop-types": "*",
     "react": "*",
-    "prop-types": "*"
+    "react-native": ">=0.46.0",
+    "react-native-pod": "^1.1.0"
   },
   "dependencies": {
     "@panter/react-animation-frame": "^0.3.7",
@@ -37,9 +44,9 @@
     "eslint-plugin-prettier": "^2.1.1",
     "eslint-plugin-react": "^7.0.1",
     "prettier": "^1.3.1",
-    "react": "16.0.0-alpha.12",
-    "prop-types": "^15.5.8"
-  }, 
+    "prop-types": "^15.5.8",
+    "react": "16.0.0-alpha.12"
+  },
   "pods": {
     "PocketSVG": "*"
   }


### PR DESCRIPTION
By deploying PocketSVG as a CocoaPod via `react-native-pod` peer dependency (which also takes care of creating the `Podfile`, you can allow automatic installation. No more opening Xcode! 

The `project.pbxproj` change tells the static library to use the parent app's Pod. 