### PR TITLE
Color grabbing

### DIFF
--- a/ARKit.js
+++ b/ARKit.js
@@ -170,17 +170,28 @@ ARKit.exportModel = presetId => {
   return ARKitManager.exportModel(property).then(result => ({ ...result, id }));
 };
 
-ARKit.getCameraColorPalette = async ({
-  whiteBalance = true,
-  includeRawColors = false,
-  ...options
-}) => {
-  const colors = await ARKitManager.getCameraColorPaletteRaw(options);
+ARKit.pickColors = async (
+  {
+    whiteBalance = true,
+    includeRawColors = false,
+    selection = null,
+    // color grabber options, currently undocumented
+    range = 40,
+    dimension = 4,
+    flexibility = 5,
+  } = {},
+) => {
+  const colors = await ARKitManager.pickColorsRaw({
+    selection,
+    range,
+    dimension,
+    flexibility,
+  });
   if (!whiteBalance) {
     return colors;
   }
   const lightEstimation = await ARKitManager.getCurrentLightEstimation();
-  console.log(lightEstimation);
+
   if (!lightEstimation) {
     return colors;
   }

--- a/ARKit.js
+++ b/ARKit.js
@@ -15,7 +15,7 @@ import {
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 
-import { whiteBalanceWithTemperature } from './lib/colorUtils';
+import { pickColors, pickColorsFromFile } from './lib/pickColors';
 import generateId from './components/lib/generateId';
 
 const ARKitManager = NativeModules.ARKitManager;
@@ -170,42 +170,8 @@ ARKit.exportModel = presetId => {
   return ARKitManager.exportModel(property).then(result => ({ ...result, id }));
 };
 
-ARKit.pickColors = async (
-  {
-    whiteBalance = true,
-    includeRawColors = false,
-    selection = null,
-    // color grabber options, currently undocumented
-    range = 40,
-    dimension = 4,
-    flexibility = 5,
-  } = {},
-) => {
-  const colors = await ARKitManager.pickColorsRaw({
-    selection,
-    range,
-    dimension,
-    flexibility,
-  });
-  if (!whiteBalance) {
-    return colors;
-  }
-  const lightEstimation = await ARKitManager.getCurrentLightEstimation();
-
-  if (!lightEstimation) {
-    return colors;
-  }
-
-  return colors.map(({ color, ...p }) => ({
-    color: whiteBalanceWithTemperature(
-      color,
-      lightEstimation.ambientColorTemperature,
-    ),
-    ...p,
-    ...(includeRawColors ? { colorRaw: color } : {}),
-  }));
-};
-
+ARKit.pickColors = pickColors;
+ARKit.pickColorsFromFile = pickColorsFromFile;
 ARKit.propTypes = {
   debug: PropTypes.bool,
   planeDetection: PropTypes.bool,

--- a/index.js
+++ b/index.js
@@ -25,6 +25,8 @@ import DeviceMotion from './DeviceMotion';
 import startup from './startup';
 import withProjectedPosition from './hocs/withProjectedPosition';
 
+import * as colorUtils from './lib/colorUtils';
+
 ARKit.Box = ARBox;
 ARKit.Sphere = ARSphere;
 ARKit.Cylinder = ARCylinder;
@@ -44,6 +46,7 @@ ARKit.Light = ARLight;
 startup();
 
 export {
+  colorUtils,
   ARKit,
   DeviceMotion,
   ARBox,

--- a/ios/RCTARKit.h
+++ b/ios/RCTARKit.h
@@ -61,8 +61,8 @@ typedef void (^RCTARKitReject)(NSString *code, NSString *message, NSError *error
 - (void)hitTestSceneObjects:(CGPoint)tapPoint resolve:(RCTARKitResolve) resolve reject:(RCTARKitReject)reject;
 - (SCNVector3)projectPoint:(SCNVector3)point;
 - (float)getCameraDistanceToPoint:(SCNVector3)point;
-- (UIImage *)getSnapshot;
-- (UIImage *)getSnapshotCamera;
+- (UIImage *)getSnapshot:(NSDictionary*)selection;
+- (UIImage *)getSnapshotCamera:(NSDictionary*)selection;
 - (void)focusScene;
 - (void)clearScene;
 - (NSDictionary *)readCameraPosition;

--- a/ios/RCTARKit.h
+++ b/ios/RCTARKit.h
@@ -61,8 +61,8 @@ typedef void (^RCTARKitReject)(NSString *code, NSString *message, NSError *error
 - (void)hitTestSceneObjects:(CGPoint)tapPoint resolve:(RCTARKitResolve) resolve reject:(RCTARKitReject)reject;
 - (SCNVector3)projectPoint:(SCNVector3)point;
 - (float)getCameraDistanceToPoint:(SCNVector3)point;
-- (UIImage *)getSnaphshot;
-- (UIImage *)getSnaphshotCamera;
+- (UIImage *)getSnapshot;
+- (UIImage *)getSnapshotCamera;
 - (void)focusScene;
 - (void)clearScene;
 - (NSDictionary *)readCameraPosition;

--- a/ios/RCTARKit.m
+++ b/ios/RCTARKit.m
@@ -252,16 +252,19 @@ static NSDictionary * vector4ToJson(const SCNVector4 v) {
 }
 
 
-- (UIImage *)getSnapshot {
+- (UIImage *)getSnapshot:(NSDictionary *)selection {
     UIImage *image = [self.arView snapshot];
-    return image;
+    
+    
+    return [self cropImage:image toSelection:selection];
+    
 }
 
 
 
 
 
-- (UIImage *)getSnapshotCamera {
+- (UIImage *)getSnapshotCamera:(NSDictionary *)selection {
     CVPixelBufferRef pixelBuffer = self.arView.session.currentFrame.capturedImage;
     CIImage *ciImage = [CIImage imageWithCVPixelBuffer:pixelBuffer];
     
@@ -274,11 +277,102 @@ static NSDictionary * vector4ToJson(const SCNVector4 v) {
     
     UIImage *image = [UIImage imageWithCGImage:videoImage scale: 1.0 orientation:UIImageOrientationRight];
     CGImageRelease(videoImage);
-    return image;
+    
+    UIImage *cropped = [self cropImage:image toSelection:selection];
+    return cropped;
+    
 }
 
 
 
+- (UIImage *)cropImage:(UIImage *)imageToCrop toRect:(CGRect)rect
+{
+    //CGRect CropRect = CGRectMake(rect.origin.x, rect.origin.y, rect.size.width, rect.size.height+15);
+    
+    CGImageRef imageRef = CGImageCreateWithImageInRect([imageToCrop CGImage], rect);
+    UIImage *cropped = [UIImage imageWithCGImage:imageRef];
+    CGImageRelease(imageRef);
+    
+    return cropped;
+}
+
+static inline double radians (double degrees) {return degrees * M_PI/180;}
+UIImage* rotate(UIImage* src, UIImageOrientation orientation)
+{
+    UIGraphicsBeginImageContext(src.size);
+    
+    CGContextRef context = UIGraphicsGetCurrentContext();
+        [src drawAtPoint:CGPointMake(0, 0)];
+    if (orientation == UIImageOrientationRight) {
+        CGContextRotateCTM (context, radians(90));
+    } else if (orientation == UIImageOrientationLeft) {
+        CGContextRotateCTM (context, radians(-90));
+    } else if (orientation == UIImageOrientationDown) {
+        // NOTHING
+    } else if (orientation == UIImageOrientationUp) {
+        CGContextRotateCTM (context, radians(90));
+    }
+    
+
+    
+    UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
+    UIGraphicsEndImageContext();
+    return image;
+}
+- (UIImage *)cropImage:(UIImage *)imageToCrop toSelection:(NSDictionary *)selection
+{
+    
+    // selection is in view-coordinate system
+    // where as the image is a camera picture with arbitary size
+    // also, the camera picture is cut of so that it "covers" the self.bounds
+    // if selection is nil, crop to the viewport
+    
+    UIImage * image = rotate(imageToCrop, imageToCrop.imageOrientation);
+    
+    float arViewWidth = self.bounds.size.width;
+    float arViewHeight = self.bounds.size.height;
+    float imageWidth = image.size.width;
+    float imageHeight = image.size.height;
+    
+    float arViewRatio = arViewHeight/arViewWidth;
+    float imageRatio = imageHeight/imageWidth;
+    float imageToArWidth = imageWidth/arViewWidth;
+    float imageToArHeight = imageHeight/arViewHeight;
+    
+    float finalHeight;
+    float finalWidth;
+    
+    
+    if (arViewRatio > imageRatio)
+    {
+        finalHeight = arViewHeight*imageToArHeight;
+        finalWidth = arViewHeight*imageToArHeight /arViewRatio;
+    }
+    else
+    {
+        finalWidth = arViewWidth*imageToArWidth;
+        finalHeight = arViewWidth * imageToArWidth * arViewRatio;
+    }
+    
+    float topOffset = (image.size.height - finalHeight)/2;
+    float leftOffset = (image.size.width - finalWidth)/2;
+    
+    
+    float x = leftOffset;
+    float y = topOffset;
+    float width = finalWidth;
+    float height = finalHeight;
+    if(selection && selection != [NSNull null]) {
+        x = leftOffset+ [selection[@"x"] floatValue]*imageToArWidth;
+        y = topOffset+[selection[@"y"] floatValue]*imageToArHeight;
+        width = [selection[@"width"] floatValue]*imageToArWidth;
+        height = [selection[@"height"] floatValue]*imageToArHeight;
+    }
+    CGRect rect = CGRectMake(x, y, width, height);
+    
+    UIImage *cropped = [self cropImage:image toRect:rect];
+    return cropped;
+}
 
 
 #pragma mark - plane hit detection
@@ -408,7 +502,7 @@ static NSDictionary * getPlaneHitResult(NSMutableArray *resultsMapped, const CGP
 
 - (void)renderer:(id <SCNSceneRenderer>)renderer didUpdateNode:(SCNNode *)node forAnchor:(ARAnchor *)anchor {
     ARPlaneAnchor *planeAnchor = (ARPlaneAnchor *)anchor;
-
+    
     if (self.onPlaneUpdate) {
         self.onPlaneUpdate(@{
                              @"id": planeAnchor.identifier.UUIDString,

--- a/ios/RCTARKit.m
+++ b/ios/RCTARKit.m
@@ -252,7 +252,7 @@ static NSDictionary * vector4ToJson(const SCNVector4 v) {
 }
 
 
-- (UIImage *)getSnaphshot {
+- (UIImage *)getSnapshot {
     UIImage *image = [self.arView snapshot];
     return image;
 }
@@ -261,7 +261,7 @@ static NSDictionary * vector4ToJson(const SCNVector4 v) {
 
 
 
-- (UIImage *)getSnaphsotCamera {
+- (UIImage *)getSnapshotCamera {
     CVPixelBufferRef pixelBuffer = self.arView.session.currentFrame.capturedImage;
     CIImage *ciImage = [CIImage imageWithCVPixelBuffer:pixelBuffer];
     

--- a/ios/RCTARKit.xcodeproj/project.pbxproj
+++ b/ios/RCTARKit.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		10ED47A71F38BC01004DF043 /* DeviceMotion.m in Sources */ = {isa = PBXBuildFile; fileRef = 10ED47A61F38BC00004DF043 /* DeviceMotion.m */; };
 		10FEF6141F774C9000EC21AE /* RCTARKitIO.m in Sources */ = {isa = PBXBuildFile; fileRef = 10FEF6101F774C8F00EC21AE /* RCTARKitIO.m */; };
 		10FEF6151F774C9000EC21AE /* RCTARKitNodes.m in Sources */ = {isa = PBXBuildFile; fileRef = 10FEF6121F774C9000EC21AE /* RCTARKitNodes.m */; };
+		B1990B221FCEEBD60001AE2F /* color-grabber.m in Sources */ = {isa = PBXBuildFile; fileRef = B1990B211FCEEBD60001AE2F /* color-grabber.m */; };
 		B3E7B58A1CC2AC0600A0062D /* RCTARKit.m in Sources */ = {isa = PBXBuildFile; fileRef = B3E7B5891CC2AC0600A0062D /* RCTARKit.m */; };
 /* End PBXBuildFile section */
 
@@ -63,6 +64,8 @@
 		134814201AA4EA6300B7C361 /* libRCTARKit.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libRCTARKit.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		B14C36631F960C500047CB67 /* PocketSVG.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PocketSVG.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B14C36651F960C6E0047CB67 /* PocketSVG.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PocketSVG.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		B1990B201FCEEBD60001AE2F /* color-grabber.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "color-grabber.h"; sourceTree = "<group>"; };
+		B1990B211FCEEBD60001AE2F /* color-grabber.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "color-grabber.m"; sourceTree = "<group>"; };
 		B3E7B5881CC2AC0600A0062D /* RCTARKit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTARKit.h; sourceTree = "<group>"; };
 		B3E7B5891CC2AC0600A0062D /* RCTARKit.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTARKit.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -102,6 +105,7 @@
 		58B511D21A9E6C8500147676 = {
 			isa = PBXGroup;
 			children = (
+				B1990B1F1FCEEBD60001AE2F /* color-grabber */,
 				106999E21F3EC2FB00032829 /* components */,
 				10ED47A51F38BC00004DF043 /* DeviceMotion.h */,
 				10ED47A61F38BC00004DF043 /* DeviceMotion.m */,
@@ -130,6 +134,15 @@
 				B14C36631F960C500047CB67 /* PocketSVG.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		B1990B1F1FCEEBD60001AE2F /* color-grabber */ = {
+			isa = PBXGroup;
+			children = (
+				B1990B201FCEEBD60001AE2F /* color-grabber.h */,
+				B1990B211FCEEBD60001AE2F /* color-grabber.m */,
+			);
+			path = "color-grabber";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -192,6 +205,7 @@
 				10FEF6141F774C9000EC21AE /* RCTARKitIO.m in Sources */,
 				10DCBC4B1F7CE836008C89E7 /* ARGeosManager.m in Sources */,
 				10FEF6151F774C9000EC21AE /* RCTARKitNodes.m in Sources */,
+				B1990B221FCEEBD60001AE2F /* color-grabber.m in Sources */,
 				10E553291F1391350059B7EC /* Plane.m in Sources */,
 				1021FE1C1F3EDB98000E7339 /* ARModelManager.m in Sources */,
 				1021FE1D1F3EDB9B000E7339 /* ARTextManager.m in Sources */,

--- a/ios/RCTARKitManager.m
+++ b/ios/RCTARKitManager.m
@@ -233,7 +233,7 @@ RCT_EXPORT_METHOD(
 }
 
 RCT_EXPORT_METHOD(snapshot:(NSDictionary *)options resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {
-    UIImage *image = [[ARKit sharedInstance] getSnaphshot];
+    UIImage *image = [[ARKit sharedInstance] getSnapshot];
     [self storeImage:image options:options reject:reject resolve:resolve];
 }
 
@@ -241,7 +241,7 @@ RCT_EXPORT_METHOD(snapshot:(NSDictionary *)options resolve:(RCTPromiseResolveBlo
 
 
 RCT_EXPORT_METHOD(snapshotCamera:(NSDictionary *)options resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {
-    UIImage *image = [[ARKit sharedInstance] getSnaphshotCamera];
+    UIImage *image = [[ARKit sharedInstance] getSnapshotCamera];
     [self storeImage:image options:options reject:reject resolve:resolve];
 }
 

--- a/ios/RCTARKitManager.m
+++ b/ios/RCTARKitManager.m
@@ -155,7 +155,7 @@ RCT_EXPORT_METHOD(
     return assetURLStr;
 }
 
-- (void)storeImageInPhotoAlbum:(UIImage *)image reject:(RCTPromiseRejectBlock)reject resolve:(RCTPromiseResolveBlock)resolve {
+- (void)storeImageInPhotoAlbum:(UIImage *)image cameraProperties:(NSDictionary *) cameraProperties  reject:(RCTPromiseRejectBlock)reject resolve:(RCTPromiseResolveBlock)resolve {
     __block PHObjectPlaceholder *placeholder;
     
     [[PHPhotoLibrary sharedPhotoLibrary] performChanges:^{
@@ -170,7 +170,7 @@ RCT_EXPORT_METHOD(
             
             NSString * assetURLStr = [self getAssetUrl:localID];
             
-            resolve(@{@"url": assetURLStr, @"width":@(image.size.width), @"height": @(image.size.height)});
+            resolve(@{@"url": assetURLStr, @"width":@(image.size.width), @"height": @(image.size.height),  @"camera":cameraProperties});
         }
         else
         {
@@ -180,7 +180,7 @@ RCT_EXPORT_METHOD(
 }
 
 
-- (void)storeImageInDirectory:(UIImage *)image directory:(NSString *)directory format:(NSString *)format reject:(RCTPromiseRejectBlock)reject resolve:(RCTPromiseResolveBlock)resolve {
+- (void)storeImageInDirectory:(UIImage *)image directory:(NSString *)directory format:(NSString *)format cameraProperties:(NSDictionary *) cameraProperties  reject:(RCTPromiseRejectBlock)reject resolve:(RCTPromiseResolveBlock)resolve {
     NSData *data;
     if([format isEqualToString:@"jpg"]) {
         data = UIImageJPEGRepresentation(image, 0.9);
@@ -198,7 +198,7 @@ RCT_EXPORT_METHOD(
     NSString *filePath = [directory stringByAppendingPathComponent:uniqueFileName]; //Add the file name
     bool success = [data writeToFile:filePath atomically:YES]; //Write the file
     if(success) {
-        resolve(@{@"url": filePath, @"width":@(image.size.width), @"height": @(image.size.height)});
+        resolve(@{@"url": filePath, @"width":@(image.size.width), @"height": @(image.size.height),  @"camera":cameraProperties});
     } else {
         // TODO use NSError from writeToFile
         reject(@"snapshot_error",  [NSString stringWithFormat:@"could not save to '%@'", filePath], nil);
@@ -206,7 +206,7 @@ RCT_EXPORT_METHOD(
     
 }
 
-- (void)storeImage:(UIImage *)image options:(NSDictionary *)options reject:(RCTPromiseRejectBlock)reject resolve:(RCTPromiseResolveBlock)resolve {
+- (void)storeImage:(UIImage *)image options:(NSDictionary *)options reject:(RCTPromiseRejectBlock)reject resolve:(RCTPromiseResolveBlock)resolve cameraProperties:(NSDictionary *)cameraProperties {
     NSString * target = @"cameraRoll";
     NSString * format = @"png";
     
@@ -218,7 +218,7 @@ RCT_EXPORT_METHOD(
     }
     if([target isEqualToString:@"cameraRoll"]) {
         // camera roll / photo album
-        [self storeImageInPhotoAlbum:image reject:reject resolve:resolve];
+        [self storeImageInPhotoAlbum:image cameraProperties:cameraProperties reject:reject resolve:resolve ];
     } else {
         NSString * dir;
         if([target isEqualToString:@"cache"]) {
@@ -229,15 +229,17 @@ RCT_EXPORT_METHOD(
         } else {
             dir = target;
         }
-        [self storeImageInDirectory:image directory:dir format:format reject:reject resolve:resolve];
+        [self storeImageInDirectory:image directory:dir format:format cameraProperties:cameraProperties reject:reject resolve:resolve ];
     }
 }
 
 RCT_EXPORT_METHOD(snapshot:(NSDictionary *)options resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         NSDictionary * selection = options[@"selection"];
+        NSDictionary * cameraProperties = [[ARKit sharedInstance] readCamera];
         UIImage *image = [[ARKit sharedInstance] getSnapshot:selection];
-        [self storeImage:image options:options reject:reject resolve:resolve];
+        
+        [self storeImage:image options:options reject:reject resolve:resolve cameraProperties:cameraProperties ];
     });
 }
 
@@ -247,21 +249,26 @@ RCT_EXPORT_METHOD(snapshot:(NSDictionary *)options resolve:(RCTPromiseResolveBlo
 RCT_EXPORT_METHOD(snapshotCamera:(NSDictionary *)options resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         NSDictionary * selection = options[@"selection"];
+        NSDictionary * cameraProperties = [[ARKit sharedInstance] readCamera];
         UIImage *image = [[ARKit sharedInstance] getSnapshotCamera:selection];
-        [self storeImage:image options:options reject:reject resolve:resolve];
+        [self storeImage:image options:options reject:reject resolve:resolve cameraProperties:cameraProperties];
     });
 }
 
 RCT_EXPORT_METHOD(pickColorsRaw:(NSDictionary *)options resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {
-    
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         
         NSDictionary * selection = options[@"selection"];
         UIImage *image = [[ARKit sharedInstance] getSnapshotCamera:selection];
         resolve([[ColorGrabber sharedInstance] getColorsFromImage:image options:options]);
     });
-    
-    
+}
+
+RCT_EXPORT_METHOD(pickColorsRawFromFile:(NSString * )filePath options:(NSDictionary *)options resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        UIImage *image = [UIImage imageWithContentsOfFile:filePath];
+        resolve([[ColorGrabber sharedInstance] getColorsFromImage:image options:options]);
+    });
 }
 
 RCT_EXPORT_METHOD(getCamera:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {

--- a/ios/RCTARKitManager.m
+++ b/ios/RCTARKitManager.m
@@ -11,6 +11,7 @@
 #import "RCTARKitNodes.h"
 #import <UIKit/UIKit.h>
 #import <Photos/Photos.h>
+#import "color-grabber.h"
 
 @implementation RCTARKitManager
 
@@ -243,6 +244,13 @@ RCT_EXPORT_METHOD(snapshot:(NSDictionary *)options resolve:(RCTPromiseResolveBlo
 RCT_EXPORT_METHOD(snapshotCamera:(NSDictionary *)options resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {
     UIImage *image = [[ARKit sharedInstance] getSnapshotCamera];
     [self storeImage:image options:options reject:reject resolve:resolve];
+}
+
+RCT_EXPORT_METHOD(getCameraColorPaletteRaw:(NSDictionary *)options resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {
+   
+    UIImage *image = [[ARKit sharedInstance] getSnapshotCamera];
+    resolve([[ColorGrabber sharedInstance] getColorsFromImage:image options:options]);
+
 }
 
 RCT_EXPORT_METHOD(getCamera:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {

--- a/ios/RCTConvert+ARKit.m
+++ b/ios/RCTConvert+ARKit.m
@@ -331,6 +331,7 @@
         material.lightingModelName = SCNLightingModelPhysicallyBased;
         material.metalness.contents = @([json[@"metalness"] floatValue]);
     }
+    
     if (json[@"roughness"]) {
         material.lightingModelName = SCNLightingModelPhysicallyBased;
         material.roughness.contents = @([json[@"roughness"] floatValue]);

--- a/ios/color-grabber/color-grabber.h
+++ b/ios/color-grabber/color-grabber.h
@@ -1,0 +1,13 @@
+//
+//  color-grabber.h
+//
+
+#import <Foundation/Foundation.h>
+#import <GLKit/GLKit.h>
+#import <React/RCTBridgeModule.h>
+
+@interface ColorGrabber : NSObject <RCTBridgeModule>
+
++ (instancetype)sharedInstance;
+- (NSArray *)getColorsFromImage:(UIImage *)image options:(NSDictionary *)options;
+@end

--- a/ios/color-grabber/color-grabber.m
+++ b/ios/color-grabber/color-grabber.m
@@ -1,0 +1,250 @@
+
+#import <React/RCTConvert.h>
+#import <AssetsLibrary/AssetsLibrary.h>
+#import "color-grabber.h"
+
+#define CLAMP(x, low, high) ({\
+__typeof__(x) __x = (x); \
+__typeof__(low) __low = (low);\
+__typeof__(high) __high = (high);\
+__x > __high ? __high : (__x < __low ? __low : __x);\
+})
+
+@implementation ColorGrabber
+
+
+
+
+RCT_EXPORT_MODULE();
+
+- (NSArray *)getColorsFromImage:(UIImage *)image options:(NSDictionary *)options {
+    
+    float dimension = [RCTConvert float:options[@"dimension"]]; // 4
+    float flexibility = [RCTConvert float:options[@"flexibility"]]; // 5;
+    float range = [RCTConvert float:options[@"range"]]; // 40;
+    
+    NSMutableArray * colours = [NSMutableArray new];
+    CGImageRef imageRef = [image CGImage];
+    CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
+    unsigned char *rawData = (unsigned char*) calloc(dimension * dimension * 4, sizeof(unsigned char));
+    NSUInteger bytesPerPixel = 4;
+    NSUInteger bytesPerRow = bytesPerPixel * dimension;
+    NSUInteger bitsPerComponent = 8;
+    CGContextRef context = CGBitmapContextCreate(rawData, dimension, dimension, bitsPerComponent, bytesPerRow, colorSpace, kCGImageAlphaPremultipliedLast | kCGBitmapByteOrder32Big);
+    CGColorSpaceRelease(colorSpace);
+    CGContextDrawImage(context, CGRectMake(0, 0, dimension, dimension), imageRef);
+    CGContextRelease(context);
+    
+    float x = 0;
+    float y = 0;
+    for (int n = 0; n<(dimension*dimension); n++){
+        
+        int index = (bytesPerRow * y) + x * bytesPerPixel;
+        int red   = rawData[index];
+        int green = rawData[index + 1];
+        int blue  = rawData[index + 2];
+        int alpha = rawData[index + 3];
+        NSArray * a = [NSArray arrayWithObjects:[NSString stringWithFormat:@"%i",red],[NSString stringWithFormat:@"%i",green],[NSString stringWithFormat:@"%i",blue],[NSString stringWithFormat:@"%i",alpha], nil];
+        [colours addObject:a];
+        
+        y++;
+        if (y==dimension){
+            y=0;
+            x++;
+        }
+    }
+    free(rawData);
+    
+    // Add some colour flexibility (adds more colours either side of the colours in the image)
+    NSArray * copyColours = [NSArray arrayWithArray:colours];
+    NSMutableArray * flexibleColours = [NSMutableArray new];
+    
+    float flexFactor = flexibility * 2 + 1;
+    float factor = flexFactor * flexFactor * 3; //(r,g,b) == *3
+    for (int n = 0; n<(dimension * dimension); n++){
+        
+        NSArray * pixelColours = copyColours[n];
+        NSMutableArray * reds = [NSMutableArray new];
+        NSMutableArray * greens = [NSMutableArray new];
+        NSMutableArray * blues = [NSMutableArray new];
+        
+        for (int p = 0; p<3; p++){
+            
+            NSString * rgbStr = pixelColours[p];
+            int rgb = [rgbStr intValue];
+            
+            for (int f = -flexibility; f<flexibility+1; f++){
+                int newRGB = rgb+f;
+                if (newRGB<0){
+                    newRGB = 0;
+                }
+                if (p==0){
+                    [reds addObject:[NSString stringWithFormat:@"%i",newRGB]];
+                } else if (p==1){
+                    [greens addObject:[NSString stringWithFormat:@"%i",newRGB]];
+                } else if (p==2){
+                    [blues addObject:[NSString stringWithFormat:@"%i",newRGB]];
+                }
+            }
+        }
+        
+        int r = 0;
+        int g = 0;
+        int b = 0;
+        for (int k = 0; k<factor; k++){
+            int red = CLAMP([reds[r] intValue], 0, 255);
+            int green = CLAMP([greens[g] intValue], 0, 255);
+            int blue = CLAMP([blues[b] intValue], 0, 255);
+            NSLog([NSString stringWithFormat:@"r: %d, g: %d, b: %d",red,green,blue]);
+            
+            NSString * rgbString = [NSString stringWithFormat:@"%i,%i,%i",red,green,blue];
+            [flexibleColours addObject:rgbString];
+            
+            b++;
+            if (b==flexFactor){ b=0; g++; }
+            if (g==flexFactor){ g=0; r++; }
+        }
+    }
+    
+    // Distinguish the colours
+    // orders the flexible colours by their occurrence
+    // then keeps them if they are sufficiently disimilar
+    
+    NSMutableDictionary * colourCounter = [NSMutableDictionary new];
+    
+    //count the occurences in the array
+    NSCountedSet *countedSet = [[NSCountedSet alloc] initWithArray:flexibleColours];
+    for (NSString *item in countedSet) {
+        NSUInteger count = [countedSet countForObject:item];
+        [colourCounter setValue:[NSNumber numberWithInteger:count] forKey:item];
+    }
+    
+    // Sort keys highest occurrence to lowest
+    NSArray *orderedKeys = [colourCounter keysSortedByValueUsingComparator:^NSComparisonResult(id obj1, id obj2){
+        return [obj2 compare:obj1];
+    }];
+    
+    // Checks if the colour is similar to another one already included
+    NSMutableArray * ranges = [NSMutableArray new];
+    for (NSString * key in orderedKeys){
+        NSArray * rgb = [key componentsSeparatedByString:@","];
+        int r = [rgb[0] intValue];
+        int g = [rgb[1] intValue];
+        int b = [rgb[2] intValue];
+        bool exclude = false;
+        for (NSString * ranged_key in ranges){
+            NSArray * ranged_rgb = [ranged_key componentsSeparatedByString:@","];
+            
+            int ranged_r = [ranged_rgb[0] intValue];
+            int ranged_g = [ranged_rgb[1] intValue];
+            int ranged_b = [ranged_rgb[2] intValue];
+            
+            if (r>= ranged_r-range && r<= ranged_r+range){
+                if (g>= ranged_g-range && g<= ranged_g+range){
+                    if (b>= ranged_b-range && b<= ranged_b+range){
+                        exclude = true;
+                    }
+                }
+            }
+        }
+        
+        if (!exclude){ [ranges addObject:key]; }
+    }
+    
+
+    
+    // If you want percentages to colours continue below
+    NSMutableDictionary * temp = [NSMutableDictionary new];
+    float totalCount = 0.0f;
+    for (NSString * rangeKey in ranges){
+        NSNumber * count = colourCounter[rangeKey];
+        totalCount += [count intValue];
+        temp[rangeKey]=count;
+    }
+    
+    // Set percentages
+    NSMutableArray * colors = [NSMutableArray new];
+    for (NSString * key in temp){
+        float count = [temp[key] floatValue];
+        float percentage = count/totalCount;
+        NSLog(@"%f",percentage);
+        NSArray * rgb = [key componentsSeparatedByString:@","];
+        float r = [rgb[0] floatValue];
+        float g = [rgb[1] floatValue];
+        float b = [rgb[2] floatValue];
+      
+       
+       
+        [colors addObject:@{
+                            @"color": @{
+                                    @"r": @(r),
+                                    @"g": @(g),
+                                    @"b": @(b)
+                                    },
+                            @"percentage":@(percentage)
+                            }];
+       
+    }
+    return colors;
+}
+
+RCT_EXPORT_METHOD(getColors:(NSString *)path options:(NSDictionary *)options resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+{
+    
+    NSURL* aURL = [NSURL URLWithString:path];
+    
+    if([path hasPrefix: @"/"]) {
+        UIImage *image = [UIImage imageWithContentsOfFile:path];
+        
+        NSArray * colors = [self getColorsFromImage:image options:options];
+        resolve(colors);
+    } else {
+        ALAssetsLibrary *library = [[ALAssetsLibrary alloc] init];
+        
+        [library assetForURL:aURL resultBlock:^(ALAsset *asset) {
+            UIImage  *image = [UIImage imageWithCGImage:[[asset defaultRepresentation] fullScreenImage] scale:0.5 orientation:UIImageOrientationUp];
+            NSArray * colors = [self getColorsFromImage:image options:options];
+            resolve(colors);
+            
+        }
+                failureBlock:^(NSError *error) {
+                    reject(@"asset error", @"cant't get colors from asset", error );
+                }];
+    }
+    
+    
+    
+    
+}
+
+- (NSString *)hexStringFromColor:(UIColor *)color {
+    const CGFloat *components = CGColorGetComponents(color.CGColor);
+    
+    CGFloat r = components[0];
+    CGFloat g = components[1];
+    CGFloat b = components[2];
+    
+    return [NSString stringWithFormat:@"#%02lX%02lX%02lX",
+            lroundf(r * 255),
+            lroundf(g * 255),
+            lroundf(b * 255)];
+}
+
+
++ (instancetype)sharedInstance {
+    static ColorGrabber *instance = nil;
+    static dispatch_once_t onceToken;
+    
+    dispatch_once(&onceToken, ^{
+        if (instance == nil) {
+            instance = [[self alloc] init];
+        }
+    });
+    return instance;
+}
+
+
+@end
+
+
+

--- a/lib/colorUtils.js
+++ b/lib/colorUtils.js
@@ -1,0 +1,43 @@
+// kudos to to https://github.com/jverhoelen/camanjs-whitebalance/blob/master/src/caman.whitebalance.js
+import { NativeModules } from 'react-native';
+
+const ARKitManager = NativeModules.ARKitManager;
+
+export const colorTemperatureToRgb = temperature => {
+  const m = global.Math;
+  const temp = temperature / 100;
+  let r;
+  let g;
+  let b;
+
+  if (temp <= 66) {
+    r = 255;
+    g = m.min(m.max(99.4708025861 * m.log(temp) - 161.1195681661, 0), 255);
+  } else {
+    r = m.min(m.max(329.698727446 * m.pow(temp - 60, -0.1332047592), 0), 255);
+    g = m.min(m.max(288.1221695283 * m.pow(temp - 60, -0.0755148492), 0), 255);
+  }
+
+  if (temp >= 66) {
+    b = 255;
+  } else if (temp <= 19) {
+    b = 0;
+  } else {
+    b = temp - 10;
+    b = m.min(m.max(138.5177312231 * m.log(b) - 305.0447927307, 0), 255);
+  }
+
+  return {
+    r,
+    g,
+    b,
+  };
+};
+export const whiteBalanceWithTemperature = ({ r, g, b }, temperature) => {
+  const temperatureRgb = colorTemperatureToRgb(temperature);
+  return {
+    r: r * 255 / temperatureRgb.r,
+    g: g * 255 / temperatureRgb.g,
+    b: b * 255 / temperatureRgb.b,
+  };
+};

--- a/lib/pickColors.js
+++ b/lib/pickColors.js
@@ -1,0 +1,65 @@
+import { NativeModules } from 'react-native';
+
+import { whiteBalanceWithTemperature } from './colorUtils';
+
+const ARKitManager = NativeModules.ARKitManager;
+
+const doWhiteBalance = async (colors, { includeRawColors }) => {
+  const lightEstimation = await ARKitManager.getCurrentLightEstimation();
+
+  if (!lightEstimation) {
+    return colors;
+  }
+
+  return colors.map(({ color, ...p }) => ({
+    color: whiteBalanceWithTemperature(
+      color,
+      lightEstimation.ambientColorTemperature,
+    ),
+    ...p,
+    ...(includeRawColors ? { colorRaw: color } : {}),
+  }));
+};
+export const pickColorsFromFile = async (
+  filePath,
+  {
+    whiteBalance = true,
+    includeRawColors = false,
+    // color grabber options, currently undocumented
+    range = 40,
+    dimension = 4,
+    flexibility = 5,
+  } = {},
+) => {
+  const colors = await ARKitManager.pickColorsRawFromFile(filePath, {
+    range,
+    dimension,
+    flexibility,
+  });
+  if (!whiteBalance) {
+    return colors;
+  }
+  return doWhiteBalance(colors, { includeRawColors });
+};
+export const pickColors = async (
+  {
+    whiteBalance = true,
+    includeRawColors = false,
+    selection = null,
+    // color grabber options, currently undocumented
+    range = 40,
+    dimension = 4,
+    flexibility = 5,
+  } = {},
+) => {
+  const colors = await ARKitManager.pickColorsRaw({
+    selection,
+    range,
+    dimension,
+    flexibility,
+  });
+  if (!whiteBalance) {
+    return colors;
+  }
+  return doWhiteBalance(colors, { includeRawColors });
+};

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "https://github.com/HippoAR/react-native-arkit.git"
   },
-  "version": "0.6.0",
+  "version": "0.6.1-beta.0",
   "description": "React Native binding for iOS ARKit",
   "author": "Zehao Li <qft.gtr@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
This PR adds a new function that grabs colors in a certain area of the the screen.

It captures a camera image and uses the algorithm from here https://github.com/bsudekum/react-native-color-grabber to extract a color palette:

```
const colors = await ARKit.pickColors({
      whiteBalance: true, // whether to do white balancing based on the estimated color temperature of the room, defaults to true
      // if whiteBalance is true, you can get the original raw colors by setting includeRawColors to true (defaults to false) 
      includeRawColors: true, 
      selection: {x,y, width, height}, // the area where you want to extracts colors from. (screen coordinates). if not set, the whole screen is used
      
    })
// colors is an array of objects { color, percentage }, where color is an object {r,g,b} and percentage the number indicating its prominence.
```

I use this algorithm https://github.com/bsudekum/react-native-color-grabber, but maybe there is a better algorithm for that.


Also `ARKit.snapshotCamera` and `ARKit.snapshot` now takes this selection parameter. If this param is not set, the picture is cropped to the size of the arview. Before, the image was always the raw camera image.

You can test this api by using the beta channel (yarn add react-native-arkit@beta)