### PR TITLE
reduce serialisation data

### DIFF
--- a/hocs/withProjectedPosition.js
+++ b/hocs/withProjectedPosition.js
@@ -5,7 +5,7 @@ import { NativeModules } from 'react-native';
 
 const ARKitManager = NativeModules.ARKitManager;
 
-const roundPoint = ({ x, y, z }, precision) => ({
+const rountPosition = ({ x, y, z }, precision) => ({
   x: round(x, precision),
   y: round(y, precision),
   z: round(z, precision),
@@ -50,7 +50,7 @@ export default ({ throttleMs = 33, overwritePosition = {} } = {}) => C =>
         if (this._isMounted) {
           if (result) {
             this.setState({
-              positionProjected: roundPoint(result.point, 3),
+              positionProjected: rountPosition(result.position, 3),
               projectionResult: result,
             });
           } else {

--- a/ios/RCTARKit.m
+++ b/ios/RCTARKit.m
@@ -422,11 +422,7 @@ UIImage* rotate(UIImage* src, UIImageOrientation orientation)
 
 static NSDictionary * getPlaneHitResult(NSMutableArray *resultsMapped, const CGPoint tapPoint) {
     return @{
-             @"results": resultsMapped,
-             @"tapPoint": @{
-                     @"x": @(tapPoint.x),
-                     @"y": @(tapPoint.y)
-                     }
+             @"results": resultsMapped
              };
 }
 

--- a/ios/RCTARKitNodes.m
+++ b/ios/RCTARKitNodes.m
@@ -144,11 +144,7 @@ CGFloat focDistance = 0.2f;
 
 static NSDictionary * getSceneObjectHitResult(NSMutableArray *resultsMapped, const CGPoint tapPoint) {
     return @{
-             @"results": resultsMapped,
-             @"tapPoint": @{
-                     @"x": @(tapPoint.x),
-                     @"y": @(tapPoint.y)
-                     }
+             @"results": resultsMapped
              };
 }
 
@@ -201,12 +197,6 @@ static SCNVector3 toSCNVector3(simd_float4 float4) {
                                                     @"y": @(position.y),
                                                     @"z": @(position.z)
                                                     },
-                                            // point is deprecated
-                                            @"point": @{
-                                                    @"x": @(position.x),
-                                                    @"y": @(position.y),
-                                                    @"z": @(position.z)
-                                                    },
                                             @"normal": @{
                                                     @"x": @(normal.x),
                                                     @"y": @(normal.y),
@@ -247,14 +237,7 @@ static SCNVector3 toSCNVector3(simd_float4 float4) {
                                             @"x": @(position.x),
                                             @"y": @(position.y),
                                             @"z": @(position.z)
-                                            },
-                                    // deprecated
-                                    @"point": @{
-                                            @"x": @(position.x),
-                                            @"y": @(position.y),
-                                            @"z": @(position.z)
                                             }
-                                    
                                     } )];
     }];
     return resultsMapped;

--- a/ios/RCTARKitNodes.m
+++ b/ios/RCTARKitNodes.m
@@ -188,32 +188,33 @@ static SCNVector3 toSCNVector3(simd_float4 float4) {
             SCNVector3 normal = result.worldNormal;
             float distance = [self getCameraDistanceToPoint:positionAbsolute];
          
-            [resultsMapped addObject:(@{
-                                        @"id": nodeId,
-                                        @"distance": @(distance),
-                                        @"positionAbsolute": @{
-                                                @"x": @(positionAbsolute.x),
-                                                @"y": @(positionAbsolute.y),
-                                                @"z": @(positionAbsolute.z)
-                                                },
-                                        @"position": @{
-                                                @"x": @(position.x),
-                                                @"y": @(position.y),
-                                                @"z": @(position.z)
-                                                },
-                                        // point is deprecated
-                                        @"point": @{
-                                                @"x": @(position.x),
-                                                @"y": @(position.y),
-                                                @"z": @(position.z)
-                                                },
-                                        @"normal": @{
-                                                @"x": @(normal.x),
-                                                @"y": @(normal.y),
-                                                @"z": @(normal.z)
-                                                
-                                                }
-                                        } )];
+            NSDictionary *result = @{
+                                            @"id": nodeId,
+                                            @"distance": @(distance),
+                                            @"positionAbsolute": @{
+                                                    @"x": @(positionAbsolute.x),
+                                                    @"y": @(positionAbsolute.y),
+                                                    @"z": @(positionAbsolute.z)
+                                                    },
+                                            @"position": @{
+                                                    @"x": @(position.x),
+                                                    @"y": @(position.y),
+                                                    @"z": @(position.z)
+                                                    },
+                                            // point is deprecated
+                                            @"point": @{
+                                                    @"x": @(position.x),
+                                                    @"y": @(position.y),
+                                                    @"z": @(position.z)
+                                                    },
+                                            @"normal": @{
+                                                    @"x": @(normal.x),
+                                                    @"y": @(normal.y),
+                                                    @"z": @(normal.z)
+                                                    
+                                                    }
+                                            };
+            [resultsMapped addObject:(result )];
         }
             
     }];


### PR DESCRIPTION
breaking:

- [x] `hitTestSceneObjects` and  `hitTestPlanes` no longer return `tapPoint` which was just a copy of the param
- [x] `hitTestSceneObjects` and  `hitTestPlanes` no longer return `point` in `results[]`, use  `position` or `positionAbsolute` instead

Others:

- [ ] try to make `positionAbsolute` or `distance` optional by providing a param to exclude it (later)