### PR TITLE
fixing the snapshot definitions

### DIFF
--- a/ARKit.js
+++ b/ARKit.js
@@ -159,13 +159,13 @@ Object.keys(ARKitManager).forEach(key => {
   ARKit[key] = ARKitManager[key];
 });
 
-const addDefaultsToSnapShotFunc = funcName => ({
-  target = 'cameraRoll',
-  format = 'png',
-}) => ARKitManager[funcName]({ target, format });
+const defaultPropsObject = {
+  target: 'cameraRoll',
+  format: 'png',
+};
 
-ARKit.snapshot = addDefaultsToSnapShotFunc('snapshot');
-ARKit.snapshotCamera = addDefaultsToSnapShotFunc('snapshotCamera');
+ARKit.snapshot = () => ARKitManager.snapshot(defaultPropsObject);
+ARKit.snapshotCamera = () => ARKitManager.snapshotCamera(defaultPropsObject);
 
 ARKit.exportModel = presetId => {
   const id = presetId || generateId();

--- a/ARKit.js
+++ b/ARKit.js
@@ -159,13 +159,13 @@ Object.keys(ARKitManager).forEach(key => {
   ARKit[key] = ARKitManager[key];
 });
 
-const defaultPropsObject = {
-  target: 'cameraRoll',
-  format: 'png',
-};
+const addDefaultsToSnapShotFunc = funcName => ({
+  target = 'cameraRoll',
+  format = 'png'
+} = {}) => ARKitManager[funcName]({ target, format });
 
-ARKit.snapshot = () => ARKitManager.snapshot(defaultPropsObject);
-ARKit.snapshotCamera = () => ARKitManager.snapshotCamera(defaultPropsObject);
+ARKit.snapshot = addDefaultsToSnapShotFunc("snapshot");
+ARKit.snapshotCamera = addDefaultsToSnapShotFunc("snapshotCamera");
 
 ARKit.exportModel = presetId => {
   const id = presetId || generateId();


### PR DESCRIPTION
The snapshot function does not work currently, because of an invalid statement in the main `ArKit.js` file. It's easily fixable by reworking it the way it is in this branch. I use this fix in my own project and it works as intended. Without that you get `Cannot read property target of undefined` when trying to call `Arkit.snapshot()`