### PR TITLE
Fix: don't ask for permission on startup

### DIFF
--- a/ARKit.js
+++ b/ARKit.js
@@ -159,13 +159,12 @@ Object.keys(ARKitManager).forEach(key => {
   ARKit[key] = ARKitManager[key];
 });
 
-const addDefaultsToSnapShotFunc = funcName => ({
-  target = 'cameraRoll',
-  format = 'png'
-} = {}) => ARKitManager[funcName]({ target, format });
+const addDefaultsToSnapShotFunc = funcName => (
+  { target = 'cameraRoll', format = 'png' } = {},
+) => ARKitManager[funcName]({ target, format });
 
-ARKit.snapshot = addDefaultsToSnapShotFunc("snapshot");
-ARKit.snapshotCamera = addDefaultsToSnapShotFunc("snapshotCamera");
+ARKit.snapshot = addDefaultsToSnapShotFunc('snapshot');
+ARKit.snapshotCamera = addDefaultsToSnapShotFunc('snapshotCamera');
 
 ARKit.exportModel = presetId => {
   const id = presetId || generateId();
@@ -197,6 +196,8 @@ ARKit.propTypes = {
   onTapOnPlaneUsingExtent: PropTypes.func,
   onTapOnPlaneNoExtent: PropTypes.func,
   onEvent: PropTypes.func,
+  isMounted: PropTypes.func,
+  isInitialized: PropTypes.func,
 };
 
 const RCTARKit = requireNativeComponent('RCTARKit', ARKit);

--- a/README.md
+++ b/README.md
@@ -546,8 +546,8 @@ It uses https://developer.apple.com/documentation/scenekit/scnscenerenderer/1522
 
 #### Which permissions does this use?
 
-- *camera access* (see section iOS Project configuration above). The user is asked for permission, as soon as you mount an `<ARKit />` component or use any of its API. If user denies access, you will get an error in `onARKitError`
-- *location service*: only needed if you use `ARKit.ARWorldAlignment.GravityAndHeading`.
+- **camera access** (see section iOS Project configuration above). The user is asked for permission, as soon as you mount an `<ARKit />` component or use any of its API. If user denies access, you will get an error in `onARKitError`
+- **location service**: only needed if you use `ARKit.ARWorldAlignment.GravityAndHeading`.
 
 #### Is there an Android / ARCore version?
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ These steps are mandatory regardless of doing a manual or automatic installation
 2. ARKit only runs on arm64-ready devices so the default build architecture should be set to arm64: go to `Build settings` ➜ `Build Active Architecture Only` and change the value to `Yes`.
 
 
+
+
 ## Usage
 
 A simple sample React Native ARKit App
@@ -83,6 +85,7 @@ export default class ReactNativeARKit extends Component {
           onPlaneDetected={console.log} // event listener for plane detection
           onPlaneUpdate={console.log} // event listener for plane update
           onPlaneRemoved={console.log} // arkit sometimes removes detected planes
+          onARKitError={console.log} // if arkit could not be initialized (e.g. missing permissions), you will get notified here
         >
           <ARKit.Box
             position={{ x: 0, y: 0, z: 0 }}
@@ -219,7 +222,7 @@ The `Plane` object has the following properties:
 
 ##### Static methods
 
-All methods return a promise with the result.
+All methods return a *promise* with the result.
 
 | Method Name | Arguments |  Notes
 |---|---|---|
@@ -232,7 +235,8 @@ All methods return a promise with the result.
 | `focusScene` |  | Sets the scene's position/rotation to where it was when first rendered (but now relative to your device's current position/rotation) |
 | `hitTestPlanes` | point, type  |  check if a plane has ben hit by point (`{x,y}`) with detection type (any of `ARKit.ARHitTestResultType`). See https://developer.apple.com/documentation/arkit/arhittestresulttype?language=objc for further information |
 | `hitTestSceneObjects` | point |  check if a scene object has ben hit by point (`{x,y}`) |
-
+| `isInitialized` | boolean | check whether arkit has been initialized (e.g. by mounting). See https://github.com/HippoAR/react-native-arkit/pull/152 for details |
+| `isMounted` | boolean | check whether arkit has been mounted. See https://github.com/HippoAR/react-native-arkit/pull/152 for details |
 
 #### 3D objects
 
@@ -537,6 +541,21 @@ E.gl you have several "walls" with ids "wall_1", "wall_2", etc.
 
 It uses https://developer.apple.com/documentation/scenekit/scnscenerenderer/1522929-hittest with some default options. Please file an issue or send a PR if you need more control over the options here!
 
+
+## FAQ:
+
+#### Which permissions does this use?
+
+- *camera access* (see section iOS Project configuration above). The user is asked for permission, as soon as you mount an `<ARKit />` component or use any of its API. If user denies access, you will get an error in `onARKitError`
+- *location service*: only needed if you use `ARKit.ARWorldAlignment.GravityAndHeading`.
+
+#### Is there an Android / ARCore version?
+
+Not yet, but there has been a proof-of-concept: https://github.com/HippoAR/react-native-arkit/issues/14. We are looking for contributors to help backporting this proof-of-conept to react-native-arkit.
+
+#### I have another question...
+
+[**Join Slack!**](https://join.slack.com/t/react-native-ar/shared_invite/enQtMjUzMzg3MjM0MTQ5LWU3Nzg2YjI4MGRjMTM1ZDBlNmIwYTE4YmM0M2U0NmY2YjBiYzQ4YzlkODExMTA0NDkwMzFhYWY4ZDE2M2Q4NGY)
 
 
 ## Contributing

--- a/ios/RCTARKit.h
+++ b/ios/RCTARKit.h
@@ -21,6 +21,7 @@ typedef void (^RCTARKitReject)(NSString *code, NSString *message, NSError *error
 @interface RCTARKit : UIView
 
 + (instancetype)sharedInstance;
++ (bool)isInitialized;
 - (instancetype)initWithARView:(ARSCNView *)arView;
 
 
@@ -72,8 +73,7 @@ typedef void (^RCTARKitReject)(NSString *code, NSString *message, NSError *error
 - (NSDictionary *)readCamera;
 - (NSDictionary* )getCurrentLightEstimation;
 - (NSArray * )getCurrentDetectedFeaturePoints;
-
-
+- (bool)isMounted;
 
 #pragma mark - Delegates
 - (void)renderer:(id <SCNSceneRenderer>)renderer didRenderScene:(SCNScene *)scene atTime:(NSTimeInterval)time;

--- a/ios/RCTARKit.m
+++ b/ios/RCTARKit.m
@@ -36,9 +36,14 @@ void dispatch_once_on_main_thread(dispatch_once_t *predicate,
 
 
 @implementation RCTARKit
+static RCTARKit *instance = nil;
+
++ (bool)isInitialized {
+    return instance !=nil;
+}
 
 + (instancetype)sharedInstance {
-    static RCTARKit *instance = nil;
+    
     static dispatch_once_t onceToken;
     
     dispatch_once_on_main_thread(&onceToken, ^{
@@ -47,7 +52,13 @@ void dispatch_once_on_main_thread(dispatch_once_t *predicate,
             instance = [[self alloc] initWithARView:arView];
         }
     });
+    
     return instance;
+}
+
+- (bool)isMounted {
+    
+    return self.superview != nil;
 }
 
 - (instancetype)initWithARView:(ARSCNView *)arView {
@@ -84,6 +95,8 @@ void dispatch_once_on_main_thread(dispatch_once_t *predicate,
     }
     return self;
 }
+
+
 
 - (void)layoutSubviews {
     [super layoutSubviews];

--- a/ios/RCTARKitManager.m
+++ b/ios/RCTARKitManager.m
@@ -134,6 +134,19 @@ RCT_EXPORT_METHOD(reset:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseReject
     resolve(@{});
 }
 
+RCT_EXPORT_METHOD(isInitialized:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {
+   resolve(@([ARKit isInitialized]));
+}
+
+RCT_EXPORT_METHOD(isMounted:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {
+    if( [ARKit isInitialized]) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            resolve(@([[ARKit sharedInstance] isMounted]));
+        });
+    } else {
+        resolve(@(NO));
+    }
+}
 
 RCT_EXPORT_METHOD(
                   hitTestPlanes: (NSDictionary *)pointDict

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "https://github.com/HippoAR/react-native-arkit.git"
   },
-  "version": "0.8.0",
+  "version": "0.9.0-beta.0",
   "description": "React Native binding for iOS ARKit",
   "author": "Zehao Li <qft.gtr@gmail.com>",
   "license": "MIT",

--- a/startup.js
+++ b/startup.js
@@ -6,8 +6,8 @@ export default () => {
   // when reloading the app, the scene should be cleared.
   // on prod, this usually does not happen, but you can reload the app in develop mode
   // without clearing, this would result in inconsistency
+  // do this only when arkit was already initialized
   ARKitManager.isInitialized().then(isInitialized => {
-    console.log('was already initialized on startup', isInitialized);
     if (isInitialized) {
       ARKitManager.clearScene();
     }

--- a/startup.js
+++ b/startup.js
@@ -6,5 +6,10 @@ export default () => {
   // when reloading the app, the scene should be cleared.
   // on prod, this usually does not happen, but you can reload the app in develop mode
   // without clearing, this would result in inconsistency
-  ARKitManager.clearScene();
+  ARKitManager.isInitialized().then(isInitialized => {
+    console.log('was already initialized on startup', isInitialized);
+    if (isInitialized) {
+      ARKitManager.clearScene();
+    }
+  });
 };


### PR DESCRIPTION
solves https://github.com/HippoAR/react-native-arkit/issues/132

Camera access is asked as soon as ARKit is initialized. 



This can be either if you mount it, or use any of the api methods (like `ARKit.getCurrentLightEstimation()`) or similar.

We always cleared the scene on startup to prevent inconsistancy when doing a "soft reload" of the app (e.g. if you do live-reload on development). 

Now, we no longer clear the scene if it has not been initialized and so camera permission is not asked until you mount the ARView _or_ use any of the api of ARKit.

We additionally provide a function that tells you whether arkit has been initialized. This is usuefull if you use the arkit api outside of a component (e.g. in a background process / saga) and want to prevent camera access until arkit has been initialized).

New API:

- `ARKit.isInitialized()` returns a promise with a boolean whether arkit has been initialized
- `ARKit.isMounted()` (experimental) returns a promise with a boolean whether arkit has been mounted (= is in view hierarchy)


