### PR TITLE
ARKit image detection & Vertical Plane Detection

### DIFF
--- a/ARKit.js
+++ b/ARKit.js
@@ -12,13 +12,14 @@ import {
   NativeModules,
   requireNativeComponent,
 } from 'react-native';
+import { keyBy, mapValues, isBoolean } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { keyBy, mapValues } from 'lodash';
 
 import {
   deprecated,
   detectionImages,
+  planeDetection,
   position,
   transition,
 } from './components/lib/propTypes';
@@ -93,6 +94,12 @@ class ARKit extends Component {
         <AR
           {...this.props}
           {...this.getCallbackProps()}
+          // fallback to old prop type (Was boolean, now is enum)
+          planeDetection={
+            isBoolean(this.props.planeDetection)
+              ? ARKit.ARPlaneDetection.Horizontal
+              : this.props.planeDetection
+          }
           onEvent={this._onEvent}
         />
         {state}
@@ -204,7 +211,7 @@ ARKit.pickColors = pickColors;
 ARKit.pickColorsFromFile = pickColorsFromFile;
 ARKit.propTypes = {
   debug: PropTypes.bool,
-  planeDetection: PropTypes.bool,
+  planeDetection,
   origin: PropTypes.shape({
     position,
     transition,

--- a/ARKit.js
+++ b/ARKit.js
@@ -89,6 +89,7 @@ class ARKit extends Component {
         </View>
       );
     }
+    console.log(this.props.planeDetection);
     return (
       <View style={this.props.style}>
         <AR

--- a/ARKit.js
+++ b/ARKit.js
@@ -14,9 +14,15 @@ import {
 } from 'react-native';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import { keyBy, mapValues } from 'lodash';
 
+import {
+  deprecated,
+  detectionImages,
+  position,
+  transition,
+} from './components/lib/propTypes';
 import { pickColors, pickColorsFromFile } from './lib/pickColors';
-import { position, transition } from './components/lib/propTypes';
 import generateId from './components/lib/generateId';
 
 const ARKitManager = NativeModules.ARKitManager;
@@ -46,6 +52,24 @@ class ARKit extends Component {
     ARKitManager.pause();
   }
 
+  getCallbackProps() {
+    return mapValues(
+      keyBy([
+        'onTapOnPlaneUsingExtent',
+        'onTapOnPlaneNoExtent',
+        'onPlaneDetected',
+        'onPlaneRemoved',
+        'onPlaneUpdated',
+        'onAnchorDetected',
+        'onAnchorUpdated',
+        'onAnchorRemoved',
+        'onTrackingState',
+        'onARKitError',
+      ]),
+      name => this.callback(name),
+    );
+  }
+
   render(AR = RCTARKit) {
     let state = null;
     if (this.props.debug) {
@@ -68,13 +92,7 @@ class ARKit extends Component {
       <View style={this.props.style}>
         <AR
           {...this.props}
-          onTapOnPlaneUsingExtent={this.callback('onTapOnPlaneUsingExtent')}
-          onTapOnPlaneNoExtent={this.callback('onTapOnPlaneNoExtent')}
-          onPlaneDetected={this.callback('onPlaneDetected')}
-          onPlaneRemoved={this.callback('onPlaneRemoved')}
-          onPlaneUpdate={this.callback('onPlaneUpdate')}
-          onTrackingState={this.callback('onTrackingState')}
-          onARKitError={this.callback('onARKitError')}
+          {...this.getCallbackProps()}
           onEvent={this._onEvent}
         />
         {state}
@@ -94,7 +112,7 @@ class ARKit extends Component {
         floor,
       });
     }
-
+    // TODO: check if we can remove this
     if (this.props.debug) {
       this.setState({
         state,
@@ -113,6 +131,16 @@ class ARKit extends Component {
     const eventListener = this.props[`on${eventName}`];
     if (eventListener) {
       eventListener(event.nativeEvent);
+    }
+  };
+
+  // handle deprecated alias
+  _onPlaneUpdated = nativeEvent => {
+    if (this.props.onPlaneUpdate) {
+      this.props.onPlaneUpdate(nativeEvent);
+    }
+    if (this.props.onPlaneUpdated) {
+      this.props.onPlaneUpdated(nativeEvent);
     }
   };
 
@@ -184,14 +212,23 @@ ARKit.propTypes = {
   lightEstimationEnabled: PropTypes.bool,
   autoenablesDefaultLighting: PropTypes.bool,
   worldAlignment: PropTypes.number,
+  detectionImages,
   onARKitError: PropTypes.func,
-  onPlaneDetected: PropTypes.func,
-  onPlaneRemoved: PropTypes.func,
+
   onFeaturesDetected: PropTypes.func,
   // onLightEstimation is called rapidly, better poll with
   // ARKit.getCurrentLightEstimation()
   onLightEstimation: PropTypes.func,
-  onPlaneUpdate: PropTypes.func,
+
+  onPlaneDetected: PropTypes.func,
+  onPlaneRemoved: PropTypes.func,
+  onPlaneUpdated: PropTypes.func,
+  onPlaneUpdate: deprecated(PropTypes.func, 'Use `onPlaneUpdated` instead'),
+
+  onAnchorDetected: PropTypes.func,
+  onAnchorRemoved: PropTypes.func,
+  onAnchorUpdated: PropTypes.func,
+
   onTrackingState: PropTypes.func,
   onTapOnPlaneUsingExtent: PropTypes.func,
   onTapOnPlaneNoExtent: PropTypes.func,

--- a/ARKit.js
+++ b/ARKit.js
@@ -89,7 +89,6 @@ class ARKit extends Component {
         </View>
       );
     }
-    console.log(this.props.planeDetection);
     return (
       <View style={this.props.style}>
         <AR

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ There is a Slack group that anyone can join for help / support / general questio
 
 [**Join Slack**](https://join.slack.com/t/react-native-ar/shared_invite/enQtMjUzMzg3MjM0MTQ5LWU3Nzg2YjI4MGRjMTM1ZDBlNmIwYTE4YmM0M2U0NmY2YjBiYzQ4YzlkODExMTA0NDkwMzFhYWY4ZDE2M2Q4NGY)
 
-# Getting started
+## Getting started
 
 `$ yarn add react-native-arkit`
 
@@ -24,16 +24,16 @@ make sure to use the latest version of yarn (>=1.x.x)
 (npm does not work properly at the moment. See https://github.com/HippoAR/react-native-arkit/issues/103)
 
 
-## Mostly automatic installation
+### Mostly automatic installation
 
 `$ react-native link react-native-arkit`
 
 ! Currently automatic installation does not work as PocketSVG is missing. Follow the manual installation
 
-## Manual installation
+### Manual installation
 
 
-## iOS
+#### iOS
 
 1. In XCode, in the project navigator, right click `Libraries` ➜ `Add Files to [your project's name]`
 2. Go to `node_modules` ➜ add `react-native-arkit/ios/RCTARKit.xcodeproj` and `react-native-arkit/ios/PocketSVG/PocketSVG.xcodeproj`
@@ -42,7 +42,7 @@ make sure to use the latest version of yarn (>=1.x.x)
 5. Run your project (`Cmd+R`)<
 
 
-### iOS Project configuration
+##### iOS Project configuration
 
 These steps are mandatory regardless of doing a manual or automatic installation:
 
@@ -57,7 +57,7 @@ These steps are mandatory regardless of doing a manual or automatic installation
 
 
 
-# Usage
+## Usage
 
 A simple sample React Native ARKit App
 
@@ -202,9 +202,9 @@ AppRegistry.registerComponent('ReactNativeARKit', () => ReactNativeARKit);
 
 
 
-## `<ARKit />`-Component
+### `<ARKit />`-Component
 
-## Props
+#### Props
 
 | Prop | Type | Note |
 |---|---|---|
@@ -215,7 +215,7 @@ AppRegistry.registerComponent('ReactNativeARKit', () => ReactNativeARKit);
 | `origin` | `{position, transition}` | Usually `{0,0,0}` is where you launched the app. If you want to have a different origin, you can set it here. E.g. if you set `origin={{position: {0,-1, 0}, transition: {duration: 1}}}` the new origin will be one meter below. If you have any objects already placed, they will get moved down using the given transition. All hit-test functions or similar will report coordinates relative to that new origin as `position`. You can get the original coordinates with `positionAbsolute` in these functions |  
 | `detectionImages` | `Array<DetectionImage>` | An Array of `DetectionImage` (see below), only available on IOS 11.3 |  
 
-### `DetectionImage`
+##### `DetectionImage`
 
 An `DetectionImage` is an image or image resource group that should be detected by ARKit.
 
@@ -231,7 +231,7 @@ You will then receive theses images in `onAnchorDetected/onAnchorUpdated`. See a
 
 We probably will add the option to load images from other sources as well (PRs encouraged).
 
-## Events
+#### Events
 
 | Event Name | Returns | Notes
 |---|---|---|
@@ -249,7 +249,7 @@ See [Planes and Anchors](#planes-and-anchors) for Details about anchors
 
 
 
-## Planes and Anchors
+#### Planes and Anchors
 
 ARKit can detect different anchors in the real world:
 
@@ -286,7 +286,7 @@ If its a `plane`-anchor, it will have these additional properties:
 
 
 
-## Static methods
+### Static methods
 
 Static Methods can directly be used on the `ARKit`-export:
 
@@ -314,9 +314,9 @@ All methods return a *promise* with the result.
 | `isInitialized` | boolean | check whether arkit has been initialized (e.g. by mounting). See https://github.com/HippoAR/react-native-arkit/pull/152 for details |
 | `isMounted` | boolean | check whether arkit has been mounted. See https://github.com/HippoAR/react-native-arkit/pull/152 for details |
 
-## 3D-Components
+### 3D-Components
 
-## General props
+#### General props
 
 Most 3d object have these common properties
 
@@ -351,7 +351,7 @@ E.g. you can scale an object on unmount:
 />
 ```
 
-## Material
+#### Material
 
 Most objects take a material property with these sub-props:
 
@@ -386,7 +386,7 @@ Map Properties:
 
 
 
-## [`<ARKit.Box />`](https://developer.apple.com/documentation/scenekit/scnbox)
+#### [`<ARKit.Box />`](https://developer.apple.com/documentation/scenekit/scnbox)
 
 
 | Prop | Type |
@@ -395,7 +395,7 @@ Map Properties:
 
 And any common object property (position, material, etc.)
 
-## [`<ARKit.Sphere />`](https://developer.apple.com/documentation/scenekit/scnsphere)
+#### [`<ARKit.Sphere />`](https://developer.apple.com/documentation/scenekit/scnsphere)
 
 
 | Prop | Type |
@@ -404,49 +404,49 @@ And any common object property (position, material, etc.)
 
 
 
-## [`<ARKit.Cylinder />`](https://developer.apple.com/documentation/scenekit/scncylinder)
+#### [`<ARKit.Cylinder />`](https://developer.apple.com/documentation/scenekit/scncylinder)
 
 
 | Prop | Type |
 |---|---|
 | `shape` | `{ radius, height }` |
 
-## [`<ARKit.Cone />`](https://developer.apple.com/documentation/scenekit/scncone)
+#### [`<ARKit.Cone />`](https://developer.apple.com/documentation/scenekit/scncone)
 
 
 | Prop | Type |
 |---|---|
 | `shape` | `{ topR, bottomR, height }` |
 
-## [`<ARKit.Pyramid />`](https://developer.apple.com/documentation/scenekit/scnpyramid)
+#### [`<ARKit.Pyramid />`](https://developer.apple.com/documentation/scenekit/scnpyramid)
 
 
 | Prop | Type |
 |---|---|
 | `shape` | `{ width, height, length }` |
 
-## [`<ARKit.Tube />`](https://developer.apple.com/documentation/scenekit/scntube)
+#### [`<ARKit.Tube />`](https://developer.apple.com/documentation/scenekit/scntube)
 
 
 | Prop | Type |
 |---|---|
 | `shape` | `{ innerR, outerR, height }` |
 
-## [`<ARKit.Torus />`](https://developer.apple.com/documentation/scenekit/scntorus)
+#### [`<ARKit.Torus />`](https://developer.apple.com/documentation/scenekit/scntorus)
 
 
 | Prop | Type |
 |---|---|
 | `shape` | `{ ringR, pipeR }` |
 
-## [`<ARKit.Capsule />`](https://developer.apple.com/documentation/scenekit/scncapsule)
+#### [`<ARKit.Capsule />`](https://developer.apple.com/documentation/scenekit/scncapsule)
 
 
 | Prop | Type |
 |---|---|
 | `shape` | `{ capR, height }` |
 
-## [`<ARKit.Plane />`](https://developer.apple.com/documentation/scenekit/scnplane)
+#### [`<ARKit.Plane />`](https://developer.apple.com/documentation/scenekit/scnplane)
 
 
 | Prop | Type |
@@ -477,7 +477,7 @@ This is a horizontal plane that only receives shadows, but is invisible otherwis
 ```
 
 
-## [`<ARKit.Text />`](https://developer.apple.com/documentation/scenekit/scntext)
+#### [`<ARKit.Text />`](https://developer.apple.com/documentation/scenekit/scntext)
 
 | Prop | Type |
 |---|---|
@@ -486,7 +486,7 @@ This is a horizontal plane that only receives shadows, but is invisible otherwis
 
 
 
-## `<ARKit.Model />`
+#### `<ARKit.Model />`
 
 SceneKit only supports `.scn` and `.dae` formats.
 
@@ -497,7 +497,7 @@ SceneKit only supports `.scn` and `.dae` formats.
 
 Objects currently don't take material property.
 
-## `<ARKit.Shape />`
+#### `<ARKit.Shape />`
 
 Creates a extruded shape by an svg path.
 See https://github.com/HippoAR/react-native-arkit/pull/89 for details
@@ -508,7 +508,7 @@ See https://github.com/HippoAR/react-native-arkit/pull/89 for details
 
 
 
-## [`<ARKit.Light />`](https://developer.apple.com/documentation/scenekit/scnlight)
+#### [`<ARKit.Light />`](https://developer.apple.com/documentation/scenekit/scnlight)
 
 Place lights on the scene!
 
@@ -535,9 +535,9 @@ Most properties described here are also supported: https://developer.apple.com/d
 This feature is new. If you experience any problem, please report an issue!
 
 
-## HOCs (higher order components)
+### HOCs (higher order components)
 
-## withProjectedPosition()
+#### withProjectedPosition()
 
 this hoc allows you to create 3D components where the position is always relative to the same point on the screen/camera, but sticks to a plane or object.
 
@@ -568,7 +568,7 @@ It's recommended that you specify a transition duration (0.1s works nice), as th
 
 Now you can use your 3D cursor like this:
 
-### Attach to a given detected horizontal plane
+##### Attach to a given detected horizontal plane
 
 Given you have detected a plane with onPlaneDetected, you can make the cursor stick to that plane:
 
@@ -598,7 +598,7 @@ You can also add a property `onProjectedPosition` to your cursor which will be c
 
 It uses https://developer.apple.com/documentation/arkit/arframe/2875718-hittest with some default options. Please file an issue or send a PR if you need more control over the options here!
 
-### Attach to a given 3D object
+##### Attach to a given 3D object
 
 You can attach the cursor on a 3D object, e.g. a non-horizontal-plane or similar:
 
@@ -630,22 +630,22 @@ E.gl you have several "walls" with ids "wall_1", "wall_2", etc.
 It uses https://developer.apple.com/documentation/scenekit/scnscenerenderer/1522929-hittest with some default options. Please file an issue or send a PR if you need more control over the options here!
 
 
-# FAQ:
+## FAQ:
 
-## Which permissions does this use?
+#### Which permissions does this use?
 
 - **camera access** (see section iOS Project configuration above). The user is asked for permission, as soon as you mount an `<ARKit />` component or use any of its API. If user denies access, you will get an error in `onARKitError`
 - **location service**: only needed if you use `ARKit.ARWorldAlignment.GravityAndHeading`.
 
-## Is there an Android / ARCore version?
+#### Is there an Android / ARCore version?
 
 Not yet, but there has been a proof-of-concept: https://github.com/HippoAR/react-native-arkit/issues/14. We are looking for contributors to help backporting this proof-of-conept to react-native-arkit.
 
-## I have another question...
+#### I have another question...
 
 [**Join Slack!**](https://join.slack.com/t/react-native-ar/shared_invite/enQtMjUzMzg3MjM0MTQ5LWU3Nzg2YjI4MGRjMTM1ZDBlNmIwYTE4YmM0M2U0NmY2YjBiYzQ4YzlkODExMTA0NDkwMzFhYWY4ZDE2M2Q4NGY)
 
 
-# Contributing
+## Contributing
 
 If you find a bug or would like to request a new feature, just [open an issue](https://github.com/HippoAR/react-native-arkit/issues/new). Your contributions are always welcome! Submit a pull request and see [`CONTRIBUTING.md`](CONTRIBUTING.md) for guidelines.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ There is a Slack group that anyone can join for help / support / general questio
 
 [**Join Slack**](https://join.slack.com/t/react-native-ar/shared_invite/enQtMjUzMzg3MjM0MTQ5LWU3Nzg2YjI4MGRjMTM1ZDBlNmIwYTE4YmM0M2U0NmY2YjBiYzQ4YzlkODExMTA0NDkwMzFhYWY4ZDE2M2Q4NGY)
 
-## Getting started
+# Getting started
 
 `$ yarn add react-native-arkit`
 
@@ -24,16 +24,16 @@ make sure to use the latest version of yarn (>=1.x.x)
 (npm does not work properly at the moment. See https://github.com/HippoAR/react-native-arkit/issues/103)
 
 
-### Mostly automatic installation
+## Mostly automatic installation
 
 `$ react-native link react-native-arkit`
 
 ! Currently automatic installation does not work as PocketSVG is missing. Follow the manual installation
 
-### Manual installation
+## Manual installation
 
 
-#### iOS
+## iOS
 
 1. In XCode, in the project navigator, right click `Libraries` ➜ `Add Files to [your project's name]`
 2. Go to `node_modules` ➜ add `react-native-arkit/ios/RCTARKit.xcodeproj` and `react-native-arkit/ios/PocketSVG/PocketSVG.xcodeproj`
@@ -42,7 +42,7 @@ make sure to use the latest version of yarn (>=1.x.x)
 5. Run your project (`Cmd+R`)<
 
 
-##### iOS Project configuration
+### iOS Project configuration
 
 These steps are mandatory regardless of doing a manual or automatic installation:
 
@@ -57,7 +57,7 @@ These steps are mandatory regardless of doing a manual or automatic installation
 
 
 
-## Usage
+# Usage
 
 A simple sample React Native ARKit App
 
@@ -202,9 +202,9 @@ AppRegistry.registerComponent('ReactNativeARKit', () => ReactNativeARKit);
 
 
 
-### `<ARKit />`-Component
+## `<ARKit />`-Component
 
-#### Props
+## Props
 
 | Prop | Type | Note |
 |---|---|---|
@@ -215,7 +215,7 @@ AppRegistry.registerComponent('ReactNativeARKit', () => ReactNativeARKit);
 | `origin` | `{position, transition}` | Usually `{0,0,0}` is where you launched the app. If you want to have a different origin, you can set it here. E.g. if you set `origin={{position: {0,-1, 0}, transition: {duration: 1}}}` the new origin will be one meter below. If you have any objects already placed, they will get moved down using the given transition. All hit-test functions or similar will report coordinates relative to that new origin as `position`. You can get the original coordinates with `positionAbsolute` in these functions |  
 | `detectionImages` | `Array<DetectionImage>` | An Array of `DetectionImage` (see below), only available on IOS 11.3 |  
 
-##### `DetectionImage`
+### `DetectionImage`
 
 An `DetectionImage` is an image or image resource group that should be detected by ARKit.
 
@@ -231,7 +231,7 @@ You will then receive theses images in `onAnchorDetected/onAnchorUpdated`. See a
 
 We probably will add the option to load images from other sources as well (PRs encouraged).
 
-#### Events
+## Events
 
 | Event Name | Returns | Notes
 |---|---|---|
@@ -249,7 +249,7 @@ See [Planes and Anchors](#planes-and-anchors) for Details about anchors
 
 
 
-#### Planes and Anchors
+## Planes and Anchors
 
 ARKit can detect different anchors in the real world:
 
@@ -286,7 +286,7 @@ If its a `plane`-anchor, it will have these additional properties:
 
 
 
-### Static methods
+## Static methods
 
 Static Methods can directly be used on the `ARKit`-export:
 
@@ -314,9 +314,9 @@ All methods return a *promise* with the result.
 | `isInitialized` | boolean | check whether arkit has been initialized (e.g. by mounting). See https://github.com/HippoAR/react-native-arkit/pull/152 for details |
 | `isMounted` | boolean | check whether arkit has been mounted. See https://github.com/HippoAR/react-native-arkit/pull/152 for details |
 
-### 3D-Components
+## 3D-Components
 
-#### General props
+## General props
 
 Most 3d object have these common properties
 
@@ -351,7 +351,7 @@ E.g. you can scale an object on unmount:
 />
 ```
 
-#### Material
+## Material
 
 Most objects take a material property with these sub-props:
 
@@ -386,7 +386,7 @@ Map Properties:
 
 
 
-#### [`<ARKit.Box />`](https://developer.apple.com/documentation/scenekit/scnbox)
+## [`<ARKit.Box />`](https://developer.apple.com/documentation/scenekit/scnbox)
 
 
 | Prop | Type |
@@ -395,7 +395,7 @@ Map Properties:
 
 And any common object property (position, material, etc.)
 
-#### [`<ARKit.Sphere />`](https://developer.apple.com/documentation/scenekit/scnsphere)
+## [`<ARKit.Sphere />`](https://developer.apple.com/documentation/scenekit/scnsphere)
 
 
 | Prop | Type |
@@ -404,49 +404,49 @@ And any common object property (position, material, etc.)
 
 
 
-#### [`<ARKit.Cylinder />`](https://developer.apple.com/documentation/scenekit/scncylinder)
+## [`<ARKit.Cylinder />`](https://developer.apple.com/documentation/scenekit/scncylinder)
 
 
 | Prop | Type |
 |---|---|
 | `shape` | `{ radius, height }` |
 
-#### [`<ARKit.Cone />`](https://developer.apple.com/documentation/scenekit/scncone)
+## [`<ARKit.Cone />`](https://developer.apple.com/documentation/scenekit/scncone)
 
 
 | Prop | Type |
 |---|---|
 | `shape` | `{ topR, bottomR, height }` |
 
-#### [`<ARKit.Pyramid />`](https://developer.apple.com/documentation/scenekit/scnpyramid)
+## [`<ARKit.Pyramid />`](https://developer.apple.com/documentation/scenekit/scnpyramid)
 
 
 | Prop | Type |
 |---|---|
 | `shape` | `{ width, height, length }` |
 
-#### [`<ARKit.Tube />`](https://developer.apple.com/documentation/scenekit/scntube)
+## [`<ARKit.Tube />`](https://developer.apple.com/documentation/scenekit/scntube)
 
 
 | Prop | Type |
 |---|---|
 | `shape` | `{ innerR, outerR, height }` |
 
-#### [`<ARKit.Torus />`](https://developer.apple.com/documentation/scenekit/scntorus)
+## [`<ARKit.Torus />`](https://developer.apple.com/documentation/scenekit/scntorus)
 
 
 | Prop | Type |
 |---|---|
 | `shape` | `{ ringR, pipeR }` |
 
-#### [`<ARKit.Capsule />`](https://developer.apple.com/documentation/scenekit/scncapsule)
+## [`<ARKit.Capsule />`](https://developer.apple.com/documentation/scenekit/scncapsule)
 
 
 | Prop | Type |
 |---|---|
 | `shape` | `{ capR, height }` |
 
-#### [`<ARKit.Plane />`](https://developer.apple.com/documentation/scenekit/scnplane)
+## [`<ARKit.Plane />`](https://developer.apple.com/documentation/scenekit/scnplane)
 
 
 | Prop | Type |
@@ -477,7 +477,7 @@ This is a horizontal plane that only receives shadows, but is invisible otherwis
 ```
 
 
-#### [`<ARKit.Text />`](https://developer.apple.com/documentation/scenekit/scntext)
+## [`<ARKit.Text />`](https://developer.apple.com/documentation/scenekit/scntext)
 
 | Prop | Type |
 |---|---|
@@ -486,7 +486,7 @@ This is a horizontal plane that only receives shadows, but is invisible otherwis
 
 
 
-#### `<ARKit.Model />`
+## `<ARKit.Model />`
 
 SceneKit only supports `.scn` and `.dae` formats.
 
@@ -497,7 +497,7 @@ SceneKit only supports `.scn` and `.dae` formats.
 
 Objects currently don't take material property.
 
-#### `<ARKit.Shape />`
+## `<ARKit.Shape />`
 
 Creates a extruded shape by an svg path.
 See https://github.com/HippoAR/react-native-arkit/pull/89 for details
@@ -508,7 +508,7 @@ See https://github.com/HippoAR/react-native-arkit/pull/89 for details
 
 
 
-#### [`<ARKit.Light />`](https://developer.apple.com/documentation/scenekit/scnlight)
+## [`<ARKit.Light />`](https://developer.apple.com/documentation/scenekit/scnlight)
 
 Place lights on the scene!
 
@@ -535,9 +535,9 @@ Most properties described here are also supported: https://developer.apple.com/d
 This feature is new. If you experience any problem, please report an issue!
 
 
-### HOCs (higher order components)
+## HOCs (higher order components)
 
-#### withProjectedPosition()
+## withProjectedPosition()
 
 this hoc allows you to create 3D components where the position is always relative to the same point on the screen/camera, but sticks to a plane or object.
 
@@ -568,7 +568,7 @@ It's recommended that you specify a transition duration (0.1s works nice), as th
 
 Now you can use your 3D cursor like this:
 
-##### Attach to a given detected horizontal plane
+### Attach to a given detected horizontal plane
 
 Given you have detected a plane with onPlaneDetected, you can make the cursor stick to that plane:
 
@@ -598,7 +598,7 @@ You can also add a property `onProjectedPosition` to your cursor which will be c
 
 It uses https://developer.apple.com/documentation/arkit/arframe/2875718-hittest with some default options. Please file an issue or send a PR if you need more control over the options here!
 
-##### Attach to a given 3D object
+### Attach to a given 3D object
 
 You can attach the cursor on a 3D object, e.g. a non-horizontal-plane or similar:
 
@@ -630,22 +630,22 @@ E.gl you have several "walls" with ids "wall_1", "wall_2", etc.
 It uses https://developer.apple.com/documentation/scenekit/scnscenerenderer/1522929-hittest with some default options. Please file an issue or send a PR if you need more control over the options here!
 
 
-## FAQ:
+# FAQ:
 
-#### Which permissions does this use?
+## Which permissions does this use?
 
 - **camera access** (see section iOS Project configuration above). The user is asked for permission, as soon as you mount an `<ARKit />` component or use any of its API. If user denies access, you will get an error in `onARKitError`
 - **location service**: only needed if you use `ARKit.ARWorldAlignment.GravityAndHeading`.
 
-#### Is there an Android / ARCore version?
+## Is there an Android / ARCore version?
 
 Not yet, but there has been a proof-of-concept: https://github.com/HippoAR/react-native-arkit/issues/14. We are looking for contributors to help backporting this proof-of-conept to react-native-arkit.
 
-#### I have another question...
+## I have another question...
 
 [**Join Slack!**](https://join.slack.com/t/react-native-ar/shared_invite/enQtMjUzMzg3MjM0MTQ5LWU3Nzg2YjI4MGRjMTM1ZDBlNmIwYTE4YmM0M2U0NmY2YjBiYzQ4YzlkODExMTA0NDkwMzFhYWY4ZDE2M2Q4NGY)
 
 
-## Contributing
+# Contributing
 
 If you find a bug or would like to request a new feature, just [open an issue](https://github.com/HippoAR/react-native-arkit/issues/new). Your contributions are always welcome! Submit a pull request and see [`CONTRIBUTING.md`](CONTRIBUTING.md) for guidelines.

--- a/README.md
+++ b/README.md
@@ -206,12 +206,12 @@ AppRegistry.registerComponent('ReactNativeARKit', () => ReactNativeARKit);
 
 ##### Props
 
-| Prop | Type | Default | Note |
-|---|---|---|---|
-| `debug` | `Boolean` | `false` | Debug mode will show the 3D axis and feature points detected.
-| `planeDetection` | `ARKit.ARPlaneDetection.{ Horizontal \| Vertical \| None }` | `Horizontal` | ARKit plane detection. Vertical is available with IOS 11.3
-| `lightEstimationEnabled` | `Boolean` | `false` | ARKit light estimation.
-| `worldAlignment` | `Enumeration` <br /> One of: `ARKit.ARWorldAlignment.Gravity`, `ARKit.ARWorldAlignment.GravityAndHeading`, `ARKit.ARWorldAlignment.Camera` (documentation [here](https://developer.apple.com/documentation/arkit/arworldalignment)) | `ARKit.ARWorldAlignment.Gravity` | **ARWorldAlignmentGravity** <br /> The coordinate system's y-axis is parallel to gravity, and its origin is the initial position of the device. **ARWorldAlignmentGravityAndHeading** <br /> The coordinate system's y-axis is parallel to gravity, its x- and z-axes are oriented to compass heading, and its origin is the initial position of the device. **ARWorldAlignmentCamera** <br /> The scene coordinate system is locked to match the orientation of the camera.|
+| Prop | Type | Note |
+|---|---|---|
+| `debug` | `Boolean` | Debug mode will show the 3D axis and feature points detected.
+| `planeDetection` | `ARKit.ARPlaneDetection.{ Horizontal \| Vertical \| None }` | ARKit plane detection. Defaults to `Horizontal`. `Vertical` is available with IOS 11.3
+| `lightEstimationEnabled` | `Boolean` | ARKit light estimation (defaults to false).
+| `worldAlignment` | `Enumeration` <br /> One of: `ARKit.ARWorldAlignment.Gravity`, `ARKit.ARWorldAlignment.GravityAndHeading`, `ARKit.ARWorldAlignment.Camera` (documentation [here](https://developer.apple.com/documentation/arkit/arworldalignment)) | **ARWorldAlignmentGravity** <br /> The coordinate system's y-axis is parallel to gravity, and its origin is the initial position of the device. **ARWorldAlignmentGravityAndHeading** <br /> The coordinate system's y-axis is parallel to gravity, its x- and z-axes are oriented to compass heading, and its origin is the initial position of the device. **ARWorldAlignmentCamera** <br /> The scene coordinate system is locked to match the orientation of the camera. Defaults to `ARKit.ARWorldAlignment.Gravity`|
 | `origin` | `{position, transition}` | Usually `{0,0,0}` is where you launched the app. If you want to have a different origin, you can set it here. E.g. if you set `origin={{position: {0,-1, 0}, transition: {duration: 1}}}` the new origin will be one meter below. If you have any objects already placed, they will get moved down using the given transition. All hit-test functions or similar will report coordinates relative to that new origin as `position`. You can get the original coordinates with `positionAbsolute` in these functions |  
 | `detectionImages` | `Array<DetectionImage>` | An Array of `DetectionImage`, only available on IOS 11.3 |  
 

--- a/README.md
+++ b/README.md
@@ -200,22 +200,22 @@ AppRegistry.registerComponent('ReactNativeARKit', () => ReactNativeARKit);
 
 <img src="screenshots/geometries.jpg" width="250">
 
-### Components
 
-#### `<ARKit />`
 
-##### Props
+### `<ARKit />`-Component
+
+#### Props
 
 | Prop | Type | Note |
 |---|---|---|
 | `debug` | `Boolean` | Debug mode will show the 3D axis and feature points detected.
 | `planeDetection` | `ARKit.ARPlaneDetection.{ Horizontal \| Vertical \| None }` | ARKit plane detection. Defaults to `Horizontal`. `Vertical` is available with IOS 11.3
 | `lightEstimationEnabled` | `Boolean` | ARKit light estimation (defaults to false).
-| `worldAlignment` | `Enumeration` <br /> One of: `ARKit.ARWorldAlignment.Gravity`, `ARKit.ARWorldAlignment.GravityAndHeading`, `ARKit.ARWorldAlignment.Camera` (documentation [here](https://developer.apple.com/documentation/arkit/arworldalignment)) | **ARWorldAlignmentGravity** <br /> The coordinate system's y-axis is parallel to gravity, and its origin is the initial position of the device. **ARWorldAlignmentGravityAndHeading** <br /> The coordinate system's y-axis is parallel to gravity, its x- and z-axes are oriented to compass heading, and its origin is the initial position of the device. **ARWorldAlignmentCamera** <br /> The scene coordinate system is locked to match the orientation of the camera. Defaults to `ARKit.ARWorldAlignment.Gravity`|
+| `worldAlignment` | `ARKit.ARWorldAlignment.{ Gravity \| GravityAndHeading \| Camera }` | **ARWorldAlignmentGravity** <br /> The coordinate system's y-axis is parallel to gravity, and its origin is the initial position of the device. **ARWorldAlignmentGravityAndHeading** <br /> The coordinate system's y-axis is parallel to gravity, its x- and z-axes are oriented to compass heading, and its origin is the initial position of the device. **ARWorldAlignmentCamera** <br /> The scene coordinate system is locked to match the orientation of the camera. Defaults to `ARKit.ARWorldAlignment.Gravity`.  [See](https://developer.apple.com/documentation/arkit/arworldalignment)|
 | `origin` | `{position, transition}` | Usually `{0,0,0}` is where you launched the app. If you want to have a different origin, you can set it here. E.g. if you set `origin={{position: {0,-1, 0}, transition: {duration: 1}}}` the new origin will be one meter below. If you have any objects already placed, they will get moved down using the given transition. All hit-test functions or similar will report coordinates relative to that new origin as `position`. You can get the original coordinates with `positionAbsolute` in these functions |  
-| `detectionImages` | `Array<DetectionImage>` | An Array of `DetectionImage`, only available on IOS 11.3 |  
+| `detectionImages` | `Array<DetectionImage>` | An Array of `DetectionImage` (see below), only available on IOS 11.3 |  
 
-###### `DetectionImage`
+##### `DetectionImage`
 
 An `DetectionImage` is an image or image resource group that should be detected by ARKit.
 
@@ -231,7 +231,7 @@ You will then receive theses images in `onAnchorDetected/onAnchorUpdated`. See a
 
 We probably will add the option to load images from other sources as well (PRs encouraged).
 
-##### Events
+#### Events
 
 | Event Name | Returns | Notes
 |---|---|---|
@@ -249,7 +249,7 @@ See [Planes and Anchors](#planes-and-anchors) for Details about anchors
 
 
 
-##### Planes and Anchors
+#### Planes and Anchors
 
 ARKit can detect different anchors in the real world:
 
@@ -285,7 +285,8 @@ If its a `plane`-anchor, it will have these additional properties:
 | `image` | `{name}` | an object with the name of the image.
 
 
-##### Static methods
+
+### Static methods
 
 Static Methods can directly be used on the `ARKit`-export:
 
@@ -313,9 +314,9 @@ All methods return a *promise* with the result.
 | `isInitialized` | boolean | check whether arkit has been initialized (e.g. by mounting). See https://github.com/HippoAR/react-native-arkit/pull/152 for details |
 | `isMounted` | boolean | check whether arkit has been mounted. See https://github.com/HippoAR/react-native-arkit/pull/152 for details |
 
-#### 3D objects
+### 3D-Components
 
-##### General props
+#### General props
 
 Most 3d object have these common properties
 

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ AppRegistry.registerComponent('ReactNativeARKit', () => ReactNativeARKit);
 | Prop | Type | Note |
 |---|---|---|
 | `debug` | `Boolean` | Debug mode will show the 3D axis and feature points detected.
-| `planeDetection` | `ARKit.ARPlaneDetection.{ Horizontal \| Vertical \| None }` | ARKit plane detection. Defaults to `Horizontal`. `Vertical` is available with IOS 11.3
+| `planeDetection` | `ARKit.ARPlaneDetection.{ Horizontal \| Vertical \| HorizontalVertical \| None }` | ARKit plane detection. Defaults to `Horizontal`. `Vertical` is available with IOS 11.3
 | `lightEstimationEnabled` | `Boolean` | ARKit light estimation (defaults to false).
 | `worldAlignment` | `ARKit.ARWorldAlignment.{ Gravity \| GravityAndHeading \| Camera }` | **ARWorldAlignmentGravity** <br /> The coordinate system's y-axis is parallel to gravity, and its origin is the initial position of the device. **ARWorldAlignmentGravityAndHeading** <br /> The coordinate system's y-axis is parallel to gravity, its x- and z-axes are oriented to compass heading, and its origin is the initial position of the device. **ARWorldAlignmentCamera** <br /> The scene coordinate system is locked to match the orientation of the camera. Defaults to `ARKit.ARWorldAlignment.Gravity`.  [See](https://developer.apple.com/documentation/arkit/arworldalignment)|
 | `origin` | `{position, transition}` | Usually `{0,0,0}` is where you launched the app. If you want to have a different origin, you can set it here. E.g. if you set `origin={{position: {0,-1, 0}, transition: {duration: 1}}}` the new origin will be one meter below. If you have any objects already placed, they will get moved down using the given transition. All hit-test functions or similar will report coordinates relative to that new origin as `position`. You can get the original coordinates with `positionAbsolute` in these functions |  
@@ -275,6 +275,7 @@ If its a `plane`-anchor, it will have these additional properties:
 
 | Property | Description
 |---|---|
+| `alignment` | `ARKit.ARPlaneAnchorAlignment.Horizontal` or `ARKit.ARPlaneAnchorAlignment.Vertical` <br /> so you can check whether it was a horizontal or vertical plane |
 | `extent` | see https://developer.apple.com/documentation/arkit/arplaneanchor?language=objc |
 | `center` | see https://developer.apple.com/documentation/arkit/arplaneanchor?language=objc |
 

--- a/components/lib/propTypes.js
+++ b/components/lib/propTypes.js
@@ -8,6 +8,25 @@ const animatableNumber = PropTypes.oneOfType([
   PropTypes.number,
   PropTypes.object,
 ]);
+
+export const deprecated = (propType, hint = null) => (
+  props,
+  propName,
+  componentName,
+) => {
+  if (props[propName]) {
+    console.warn(
+      `Prop \`${propName}\` supplied to` +
+        ` \`${componentName}\` is deprecated. ${hint}`,
+    );
+  }
+  return PropTypes.checkPropTypes(
+    { [propName]: propType },
+    props,
+    propName,
+    componentName,
+  );
+};
 export const position = PropTypes.shape({
   x: animatableNumber,
   y: animatableNumber,
@@ -116,3 +135,8 @@ export const material = PropTypes.shape({
   transparency: PropTypes.number,
   fillMode,
 });
+
+const detectionImage = PropTypes.shape({
+  resourceGroupName: PropTypes.string,
+});
+export const detectionImages = PropTypes.arrayOf(detectionImage);

--- a/components/lib/propTypes.js
+++ b/components/lib/propTypes.js
@@ -38,6 +38,10 @@ export const categoryBitMask = PropTypes.number;
 export const transition = PropTypes.shape({
   duration: PropTypes.number,
 });
+
+export const planeDetection = PropTypes.oneOf(
+  values(ARKitManager.ARPlaneDetection),
+);
 export const eulerAngles = PropTypes.shape({
   x: animatableNumber,
   y: animatableNumber,

--- a/ios/RCTARKit.h
+++ b/ios/RCTARKit.h
@@ -44,9 +44,16 @@ typedef void (^RCTARKitReject)(NSString *code, NSString *message, NSError *error
 
 @property (nonatomic, copy) RCTBubblingEventBlock onPlaneDetected;
 @property (nonatomic, copy) RCTBubblingEventBlock onPlaneRemoved;
+@property (nonatomic, copy) RCTBubblingEventBlock onPlaneUpdated;
+
+@property (nonatomic, copy) RCTBubblingEventBlock onAnchorDetected;
+@property (nonatomic, copy) RCTBubblingEventBlock onAnchorRemoved;
+@property (nonatomic, copy) RCTBubblingEventBlock onAnchorUpdated;
+
+
 @property (nonatomic, copy) RCTBubblingEventBlock onFeaturesDetected;
 @property (nonatomic, copy) RCTBubblingEventBlock onLightEstimation;
-@property (nonatomic, copy) RCTBubblingEventBlock onPlaneUpdate;
+
 @property (nonatomic, copy) RCTBubblingEventBlock onTrackingState;
 @property (nonatomic, copy) RCTBubblingEventBlock onTapOnPlaneUsingExtent;
 @property (nonatomic, copy) RCTBubblingEventBlock onTapOnPlaneNoExtent;

--- a/ios/RCTARKit.h
+++ b/ios/RCTARKit.h
@@ -35,7 +35,7 @@ typedef void (^RCTARKitReject)(NSString *code, NSString *message, NSError *error
 @property (nonatomic, strong) RCTARKitNodes *nodeManager;
 
 @property (nonatomic, assign) BOOL debug;
-@property (nonatomic, assign) BOOL planeDetection;
+@property (nonatomic, assign) ARPlaneDetection planeDetection;
 @property (nonatomic, assign) BOOL lightEstimationEnabled;
 @property (nonatomic, assign) BOOL autoenablesDefaultLighting;
 @property (nonatomic, assign) NSDictionary* origin;

--- a/ios/RCTARKit.h
+++ b/ios/RCTARKit.h
@@ -40,6 +40,7 @@ typedef void (^RCTARKitReject)(NSString *code, NSString *message, NSError *error
 @property (nonatomic, assign) BOOL autoenablesDefaultLighting;
 @property (nonatomic, assign) NSDictionary* origin;
 @property (nonatomic, assign) ARWorldAlignment worldAlignment;
+@property (nonatomic, assign) NSArray* detectionImages;
 
 @property (nonatomic, copy) RCTBubblingEventBlock onPlaneDetected;
 @property (nonatomic, copy) RCTBubblingEventBlock onPlaneRemoved;

--- a/ios/RCTARKit.m
+++ b/ios/RCTARKit.m
@@ -519,6 +519,14 @@ static NSDictionary * getPlaneHitResult(NSMutableArray *resultsMapped, const CGP
         ARPlaneAnchor *planeAnchor = (ARPlaneAnchor *)anchor;
         NSDictionary * planeProperties = [self makePlaneAnchorProperties:planeAnchor];
         [dict addEntriesFromDictionary:planeProperties];
+    } else if (@available(iOS 11.3, *)) {
+        if([anchor isKindOfClass:[ARImageAnchor class]]) {
+            ARImageAnchor *imageAnchor = (ARImageAnchor *)anchor;
+            NSDictionary * imageProperties = [self makeImageAnchorProperties:imageAnchor];
+            [dict addEntriesFromDictionary:imageProperties];
+        }
+    } else {
+        // Fallback on earlier versions
     }
     return dict;
 }
@@ -534,6 +542,16 @@ static NSDictionary * getPlaneHitResult(NSMutableArray *resultsMapped, const CGP
     
 }
 
+- (NSDictionary *)makeImageAnchorProperties:(ARImageAnchor *)imageAnchor  API_AVAILABLE(ios(11.3)){
+    return @{
+             @"type": @"image",
+             @"image": @{
+                     @"name": imageAnchor.referenceImage.name
+                     }
+             
+             };
+    
+}
 
 - (void)renderer:(id <SCNSceneRenderer>)renderer willUpdateNode:(SCNNode *)node forAnchor:(ARAnchor *)anchor {
 }

--- a/ios/RCTARKit.m
+++ b/ios/RCTARKit.m
@@ -87,7 +87,7 @@ static RCTARKit *instance = nil;
         
         arView.scene.rootNode.name = @"root";
         
-    
+        
         
         // start ARKit
         [self addSubview:arView];
@@ -119,7 +119,7 @@ static RCTARKit *instance = nil;
         NSLog(@"Initializing ARKIT failed with Error: %@ %@", error, [error userInfo]);
         
     }
-   
+    
 }
 - (void)reset {
     if (ARWorldTrackingConfiguration.isSupported) {
@@ -179,7 +179,7 @@ static RCTARKit *instance = nil;
 }
 
 -(void)setOrigin:(NSDictionary*)json {
-   
+    
     if(json[@"transition"]) {
         NSDictionary * transition =json[@"transition"];
         if(transition[@"duration"]) {
@@ -191,7 +191,7 @@ static RCTARKit *instance = nil;
     } else {
         [SCNTransaction setAnimationDuration:0.0];
     }
-     SCNVector3 position = [RCTConvert SCNVector3:json[@"position"]];
+    SCNVector3 position = [RCTConvert SCNVector3:json[@"position"]];
     [self.nodeManager.localOrigin setPosition:position];
 }
 
@@ -229,6 +229,26 @@ static RCTARKit *instance = nil;
         configuration.worldAlignment = ARWorldAlignmentGravity;
     }
     [self resume];
+}
+
+- (void)setDetectionImages:(NSArray*) detectionImages {
+    
+    if (@available(iOS 11.3, *)) {
+        ARWorldTrackingConfiguration *configuration = self.configuration;
+        NSMutableSet *detectionImagesSet = [[NSMutableSet alloc] init];
+        for (id config in detectionImages) {
+            if(config[@"resourceGroupName"]) {
+                // TODO: allow bundle to be defined
+                [detectionImagesSet setByAddingObjectsFromSet:[ARReferenceImage referenceImagesInGroupNamed:config[@"resourceGroupName"] bundle:nil]];
+            }
+            // do something with object
+        }
+        configuration.detectionImages = detectionImagesSet;
+        [self resume];;
+    } else {
+        // Fallback on earlier versions
+    }
+    
 }
 
 - (NSDictionary *)readCameraPosition {
@@ -508,7 +528,7 @@ static NSDictionary * getPlaneHitResult(NSMutableArray *resultsMapped, const CGP
     if (![anchor isKindOfClass:[ARPlaneAnchor class]]) {
         return;
     }
- 
+    
     ARPlaneAnchor *planeAnchor = (ARPlaneAnchor *)anchor;
     if (self.onPlaneDetected) {
         self.onPlaneDetected([self makePlaneDetectionResult:node planeAnchor:planeAnchor]);
@@ -526,7 +546,7 @@ static NSDictionary * getPlaneHitResult(NSMutableArray *resultsMapped, const CGP
 }
 
 - (void)renderer:(id<SCNSceneRenderer>)renderer didRemoveNode:(SCNNode *)node forAnchor:(ARAnchor *)anchor {
-     ARPlaneAnchor *planeAnchor = (ARPlaneAnchor *)anchor;
+    ARPlaneAnchor *planeAnchor = (ARPlaneAnchor *)anchor;
     if (self.onPlaneRemoved) {
         self.onPlaneRemoved([self makePlaneDetectionResult:node planeAnchor:planeAnchor]);
     }

--- a/ios/RCTARKit.m
+++ b/ios/RCTARKit.m
@@ -94,7 +94,7 @@ static RCTARKit *instance = nil;
         arView.defaultCameraController.inertiaEnabled = YES;
         [arView.defaultCameraController translateInCameraSpaceByX:(float) 0.0 Y:(float) 0.0 Z:(float) 3.0];
         
-        #endif        
+        #endif
         // start ARKit
         [self addSubview:arView];
         [self resume];
@@ -163,18 +163,15 @@ static RCTARKit *instance = nil;
     }
 }
 
-- (BOOL)planeDetection {
+- (ARPlaneDetection)planeDetection {
     ARWorldTrackingConfiguration *configuration = (ARWorldTrackingConfiguration *) self.configuration;
-    return configuration.planeDetection == ARPlaneDetectionHorizontal;
+    return configuration.planeDetection;
 }
 
-- (void)setPlaneDetection:(BOOL)planeDetection {
+- (void)setPlaneDetection:(ARPlaneDetection)planeDetection {
     ARWorldTrackingConfiguration *configuration = (ARWorldTrackingConfiguration *) self.configuration;
-    if (planeDetection) {
-        configuration.planeDetection = ARPlaneDetectionHorizontal;
-    } else {
-        configuration.planeDetection = ARPlaneDetectionNone;
-    }
+   
+    configuration.planeDetection = planeDetection;
     [self resume];
 }
 
@@ -516,11 +513,13 @@ static NSDictionary * getPlaneHitResult(NSMutableArray *resultsMapped, const CGP
 - (NSDictionary *)makeAnchorDetectionResult:(SCNNode *)node anchor:(ARAnchor *)anchor {
     NSDictionary* baseProps = @{
                                 @"id": anchor.identifier.UUIDString,
+                                @"type": @"unkown",
                                 @"eulerAngles":vectorToJson(node.eulerAngles),
                                 @"position": vectorToJson([self.nodeManager getRelativePositionToOrigin:node.position]),
                                 @"positionAbsolute": vectorToJson(node.position)
                                 };
     NSMutableDictionary* dict = [NSMutableDictionary dictionaryWithDictionary:baseProps];
+    
     if([anchor isKindOfClass:[ARPlaneAnchor class]]) {
         ARPlaneAnchor *planeAnchor = (ARPlaneAnchor *)anchor;
         NSDictionary * planeProperties = [self makePlaneAnchorProperties:planeAnchor];

--- a/ios/RCTARKitManager.m
+++ b/ios/RCTARKitManager.m
@@ -31,7 +31,7 @@ RCT_EXPORT_MODULE()
 
 - (NSDictionary *)constantsToExport
 {
-    
+
     return @{
              @"ARHitTestResultType": @{
                      @"FeaturePoint": @(ARHitTestResultTypeFeaturePoint),
@@ -67,7 +67,7 @@ RCT_EXPORT_MODULE()
                      @"Red": [@(SCNColorMaskRed) stringValue],
                      @"Green": [@(SCNColorMaskGreen) stringValue],
                      },
-             
+
              @"ShaderModifierEntryPoint": @{
                      @"Geometry": SCNShaderModifierEntryPointGeometry,
                      @"Surface": SCNShaderModifierEntryPointSurface,
@@ -81,13 +81,13 @@ RCT_EXPORT_MODULE()
                      @"Multiply": [@(SCNBlendModeMultiply) stringValue],
                      @"Screen": [@(SCNBlendModeScreen) stringValue],
                      @"Replace": [@(SCNBlendModeReplace) stringValue],
-                     
+
                      },
              @"ChamferMode": @{
                      @"Both": [@(SCNChamferModeBoth) stringValue],
                      @"Back": [@(SCNChamferModeBack) stringValue],
                      @"Front": [@(SCNChamferModeBack) stringValue],
-                     
+
                      },
              @"ARWorldAlignment": @{
                      @"Gravity": @(ARWorldAlignmentGravity),
@@ -115,8 +115,13 @@ RCT_EXPORT_VIEW_PROPERTY(worldAlignment, NSInteger)
 RCT_EXPORT_VIEW_PROPERTY(detectionImages, NSArray *)
 
 RCT_EXPORT_VIEW_PROPERTY(onPlaneDetected, RCTBubblingEventBlock)
-RCT_EXPORT_VIEW_PROPERTY(onPlaneUpdate, RCTBubblingEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onPlaneUpdated, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onPlaneRemoved, RCTBubblingEventBlock)
+
+RCT_EXPORT_VIEW_PROPERTY(onAnchorDetected, RCTBubblingEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onAnchorUpdated, RCTBubblingEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onAnchorRemoved, RCTBubblingEventBlock)
+
 RCT_EXPORT_VIEW_PROPERTY(onTrackingState, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onFeaturesDetected, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onLightEstimation, RCTBubblingEventBlock)
@@ -187,19 +192,19 @@ RCT_EXPORT_METHOD(
 
 - (void)storeImageInPhotoAlbum:(UIImage *)image cameraProperties:(NSDictionary *) cameraProperties  reject:(RCTPromiseRejectBlock)reject resolve:(RCTPromiseResolveBlock)resolve {
     __block PHObjectPlaceholder *placeholder;
-    
+
     [[PHPhotoLibrary sharedPhotoLibrary] performChanges:^{
         PHAssetChangeRequest* createAssetRequest = [PHAssetChangeRequest creationRequestForAssetFromImage:image];
         placeholder = [createAssetRequest placeholderForCreatedAsset];
-        
+
     } completionHandler:^(BOOL success, NSError *error) {
         if (success)
         {
-            
+
             NSString * localID = placeholder.localIdentifier;
-            
+
             NSString * assetURLStr = [self getAssetUrl:localID];
-            
+
             resolve(@{@"url": assetURLStr, @"width":@(image.size.width), @"height": @(image.size.height),  @"camera":cameraProperties});
         }
         else
@@ -221,10 +226,10 @@ RCT_EXPORT_METHOD(
         return;
     }
     NSString *prefixString = @"capture";
-    
+
     NSString *guid = [[NSProcessInfo processInfo] globallyUniqueString] ;
     NSString *uniqueFileName = [NSString stringWithFormat:@"%@_%@.%@", prefixString, guid, format];
-    
+
     NSString *filePath = [directory stringByAppendingPathComponent:uniqueFileName]; //Add the file name
     bool success = [data writeToFile:filePath atomically:YES]; //Write the file
     if(success) {
@@ -233,13 +238,13 @@ RCT_EXPORT_METHOD(
         // TODO use NSError from writeToFile
         reject(@"snapshot_error",  [NSString stringWithFormat:@"could not save to '%@'", filePath], nil);
     }
-    
+
 }
 
 - (void)storeImage:(UIImage *)image options:(NSDictionary *)options reject:(RCTPromiseRejectBlock)reject resolve:(RCTPromiseResolveBlock)resolve cameraProperties:(NSDictionary *)cameraProperties {
     NSString * target = @"cameraRoll";
     NSString * format = @"png";
-    
+
     if(options[@"target"]) {
         target = options[@"target"];
     }
@@ -255,7 +260,7 @@ RCT_EXPORT_METHOD(
             dir =  [NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES) firstObject];
         } else if([target isEqualToString:@"documents"]) {
             dir =  [NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES) firstObject];
-            
+
         } else {
             dir = target;
         }
@@ -268,7 +273,7 @@ RCT_EXPORT_METHOD(snapshot:(NSDictionary *)options resolve:(RCTPromiseResolveBlo
         NSDictionary * selection = options[@"selection"];
         NSDictionary * cameraProperties = [[ARKit sharedInstance] readCamera];
         UIImage *image = [[ARKit sharedInstance] getSnapshot:selection];
-        
+
         [self storeImage:image options:options reject:reject resolve:resolve cameraProperties:cameraProperties ];
     });
 }
@@ -287,7 +292,7 @@ RCT_EXPORT_METHOD(snapshotCamera:(NSDictionary *)options resolve:(RCTPromiseReso
 
 RCT_EXPORT_METHOD(pickColorsRaw:(NSDictionary *)options resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-        
+
         NSDictionary * selection = options[@"selection"];
         UIImage *image = [[ARKit sharedInstance] getSnapshotCamera:selection];
         resolve([[ColorGrabber sharedInstance] getColorsFromImage:image options:options]);
@@ -330,7 +335,7 @@ RCT_EXPORT_METHOD(projectPoint:
               @"z": @(pointProjected.z),
               @"distance": @(distance)
               });
-    
+
 }
 
 RCT_EXPORT_METHOD(focusScene:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {

--- a/ios/RCTARKitManager.m
+++ b/ios/RCTARKitManager.m
@@ -31,14 +31,49 @@ RCT_EXPORT_MODULE()
 
 - (NSDictionary *)constantsToExport
 {
-
+    
+    NSMutableDictionary * arHitTestResultType =
+    [NSMutableDictionary dictionaryWithDictionary:
+     @{
+       @"FeaturePoint": @(ARHitTestResultTypeFeaturePoint),
+       @"EstimatedHorizontalPlane": @(ARHitTestResultTypeEstimatedHorizontalPlane),
+       @"ExistingPlane": @(ARHitTestResultTypeExistingPlane),
+       @"ExistingPlaneUsingExtent": @(ARHitTestResultTypeExistingPlaneUsingExtent),
+       }];
+    NSMutableDictionary * arAnchorAligment =
+    [NSMutableDictionary
+     dictionaryWithDictionary:@{
+                                @"Horizontal": @(ARPlaneAnchorAlignmentHorizontal)
+                                }];
+    NSMutableDictionary * arPlaneDetection =
+    [NSMutableDictionary
+     dictionaryWithDictionary:@{
+                                @"Horizontal": @(ARPlaneDetectionHorizontal),
+                                @"None": @(ARPlaneDetectionNone),
+                                }];
+    if (@available(iOS 11.3, *)) {
+        [arHitTestResultType
+         addEntriesFromDictionary:@{
+                                    @"ExistingPlaneUsingGeometry": @(ARHitTestResultTypeExistingPlaneUsingGeometry),
+                                    @"EstimatedVerticalPlane": @(ARHitTestResultTypeEstimatedVerticalPlane)
+                                    }];
+        [arPlaneDetection
+         addEntriesFromDictionary:@{
+                                    @"Vertical": @(ARPlaneDetectionVertical),
+                                    }];
+        [arAnchorAligment
+         addEntriesFromDictionary:@{
+                                    @"Vertical": @(ARPlaneAnchorAlignmentVertical)
+                                    }];
+    }
+    
+    
+    
+    
     return @{
-             @"ARHitTestResultType": @{
-                     @"FeaturePoint": @(ARHitTestResultTypeFeaturePoint),
-                     @"EstimatedHorizontalPlane": @(ARHitTestResultTypeEstimatedHorizontalPlane),
-                     @"ExistingPlane": @(ARHitTestResultTypeExistingPlane),
-                     @"ExistingPlaneUsingExtent": @(ARHitTestResultTypeExistingPlaneUsingExtent)
-                     },
+             @"ARHitTestResultType": arHitTestResultType,
+             @"ARPlaneDetection": arPlaneDetection,
+             @"ARPlaneAnchorAlignment": arAnchorAligment,
              @"LightingModel": @{
                      @"Constant": SCNLightingModelConstant,
                      @"Blinn": SCNLightingModelBlinn,
@@ -67,7 +102,7 @@ RCT_EXPORT_MODULE()
                      @"Red": [@(SCNColorMaskRed) stringValue],
                      @"Green": [@(SCNColorMaskGreen) stringValue],
                      },
-
+             
              @"ShaderModifierEntryPoint": @{
                      @"Geometry": SCNShaderModifierEntryPointGeometry,
                      @"Surface": SCNShaderModifierEntryPointSurface,
@@ -81,13 +116,13 @@ RCT_EXPORT_MODULE()
                      @"Multiply": [@(SCNBlendModeMultiply) stringValue],
                      @"Screen": [@(SCNBlendModeScreen) stringValue],
                      @"Replace": [@(SCNBlendModeReplace) stringValue],
-
+                     
                      },
              @"ChamferMode": @{
                      @"Both": [@(SCNChamferModeBoth) stringValue],
                      @"Back": [@(SCNChamferModeBack) stringValue],
                      @"Front": [@(SCNChamferModeBack) stringValue],
-
+                     
                      },
              @"ARWorldAlignment": @{
                      @"Gravity": @(ARWorldAlignmentGravity),
@@ -114,7 +149,7 @@ RCT_EXPORT_MODULE()
 }
 
 RCT_EXPORT_VIEW_PROPERTY(debug, BOOL)
-RCT_EXPORT_VIEW_PROPERTY(planeDetection, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(planeDetection, ARPlaneDetection)
 RCT_EXPORT_VIEW_PROPERTY(origin, NSDictionary *)
 RCT_EXPORT_VIEW_PROPERTY(lightEstimationEnabled, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(autoenablesDefaultLighting, BOOL)
@@ -153,7 +188,7 @@ RCT_EXPORT_METHOD(reset:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseReject
 }
 
 RCT_EXPORT_METHOD(isInitialized:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {
-   resolve(@([ARKit isInitialized]));
+    resolve(@([ARKit isInitialized]));
 }
 
 RCT_EXPORT_METHOD(isMounted:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {
@@ -199,19 +234,19 @@ RCT_EXPORT_METHOD(
 
 - (void)storeImageInPhotoAlbum:(UIImage *)image cameraProperties:(NSDictionary *) cameraProperties  reject:(RCTPromiseRejectBlock)reject resolve:(RCTPromiseResolveBlock)resolve {
     __block PHObjectPlaceholder *placeholder;
-
+    
     [[PHPhotoLibrary sharedPhotoLibrary] performChanges:^{
         PHAssetChangeRequest* createAssetRequest = [PHAssetChangeRequest creationRequestForAssetFromImage:image];
         placeholder = [createAssetRequest placeholderForCreatedAsset];
-
+        
     } completionHandler:^(BOOL success, NSError *error) {
         if (success)
         {
-
+            
             NSString * localID = placeholder.localIdentifier;
-
+            
             NSString * assetURLStr = [self getAssetUrl:localID];
-
+            
             resolve(@{@"url": assetURLStr, @"width":@(image.size.width), @"height": @(image.size.height),  @"camera":cameraProperties});
         }
         else
@@ -233,10 +268,10 @@ RCT_EXPORT_METHOD(
         return;
     }
     NSString *prefixString = @"capture";
-
+    
     NSString *guid = [[NSProcessInfo processInfo] globallyUniqueString] ;
     NSString *uniqueFileName = [NSString stringWithFormat:@"%@_%@.%@", prefixString, guid, format];
-
+    
     NSString *filePath = [directory stringByAppendingPathComponent:uniqueFileName]; //Add the file name
     bool success = [data writeToFile:filePath atomically:YES]; //Write the file
     if(success) {
@@ -245,13 +280,13 @@ RCT_EXPORT_METHOD(
         // TODO use NSError from writeToFile
         reject(@"snapshot_error",  [NSString stringWithFormat:@"could not save to '%@'", filePath], nil);
     }
-
+    
 }
 
 - (void)storeImage:(UIImage *)image options:(NSDictionary *)options reject:(RCTPromiseRejectBlock)reject resolve:(RCTPromiseResolveBlock)resolve cameraProperties:(NSDictionary *)cameraProperties {
     NSString * target = @"cameraRoll";
     NSString * format = @"png";
-
+    
     if(options[@"target"]) {
         target = options[@"target"];
     }
@@ -267,7 +302,7 @@ RCT_EXPORT_METHOD(
             dir =  [NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES) firstObject];
         } else if([target isEqualToString:@"documents"]) {
             dir =  [NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES) firstObject];
-
+            
         } else {
             dir = target;
         }
@@ -280,7 +315,7 @@ RCT_EXPORT_METHOD(snapshot:(NSDictionary *)options resolve:(RCTPromiseResolveBlo
         NSDictionary * selection = options[@"selection"];
         NSDictionary * cameraProperties = [[ARKit sharedInstance] readCamera];
         UIImage *image = [[ARKit sharedInstance] getSnapshot:selection];
-
+        
         [self storeImage:image options:options reject:reject resolve:resolve cameraProperties:cameraProperties ];
     });
 }
@@ -299,7 +334,7 @@ RCT_EXPORT_METHOD(snapshotCamera:(NSDictionary *)options resolve:(RCTPromiseReso
 
 RCT_EXPORT_METHOD(pickColorsRaw:(NSDictionary *)options resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-
+        
         NSDictionary * selection = options[@"selection"];
         UIImage *image = [[ARKit sharedInstance] getSnapshotCamera:selection];
         resolve([[ColorGrabber sharedInstance] getColorsFromImage:image options:options]);
@@ -342,7 +377,7 @@ RCT_EXPORT_METHOD(projectPoint:
               @"z": @(pointProjected.z),
               @"distance": @(distance)
               });
-
+    
 }
 
 RCT_EXPORT_METHOD(focusScene:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {

--- a/ios/RCTARKitManager.m
+++ b/ios/RCTARKitManager.m
@@ -112,6 +112,7 @@ RCT_EXPORT_VIEW_PROPERTY(origin, NSDictionary *)
 RCT_EXPORT_VIEW_PROPERTY(lightEstimationEnabled, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(autoenablesDefaultLighting, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(worldAlignment, NSInteger)
+RCT_EXPORT_VIEW_PROPERTY(detectionImages, NSArray *)
 
 RCT_EXPORT_VIEW_PROPERTY(onPlaneDetected, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onPlaneUpdate, RCTBubblingEventBlock)

--- a/ios/RCTARKitManager.m
+++ b/ios/RCTARKitManager.m
@@ -60,6 +60,7 @@ RCT_EXPORT_MODULE()
         [arPlaneDetection
          addEntriesFromDictionary:@{
                                     @"Vertical": @(ARPlaneDetectionVertical),
+                                     @"HorizontalVertical": @(ARPlaneDetectionHorizontal + ARPlaneDetectionVertical),
                                     }];
         [arAnchorAligment
          addEntriesFromDictionary:@{

--- a/ios/RCTConvert+ARKit.h
+++ b/ios/RCTConvert+ARKit.h
@@ -9,6 +9,7 @@
 #import <Foundation/Foundation.h>
 #import <SceneKit/SceneKit.h>
 #import <React/RCTConvert.h>
+#import <ARKit/ARKit.h>
 
 @interface SCNTextNode : SCNNode
 @end
@@ -40,6 +41,8 @@
 + (void)setMaterialProperties:(SCNMaterial *)material properties:(id)json;
 + (void)setShapeProperties:(SCNGeometry *)geometry properties:(id)json;
 + (void)setLightProperties:(SCNLight *)light properties:(id)json;
+
++ (ARPlaneDetection)ARPlaneDetection:(id)number;
 
 @end
 

--- a/ios/RCTConvert+ARKit.m
+++ b/ios/RCTConvert+ARKit.m
@@ -592,5 +592,10 @@
     }
 }
 
++ (ARPlaneDetection)ARPlaneDetection:(id)number {
+    return (ARPlaneDetection)  [number integerValue];
+}
+
+
 
 @end


### PR DESCRIPTION
## Image detection 

Usage:

```
<ARKit 
  detectionImages={[{ resourceGroupName: 'DetectionImages' }]}
  onAnchorDetected={onAnchorUpdated}
  onAnchorUpdated={onAnchorUpdated}
  onAnchorRemoved={onAnchorRemoved}
/>

```

- `detectionImages` is an array of objects. Currently only images from assets are possible, but in future, we also want to enable images from filesystem, remote, etc. 
- to add an image to detect to xcode, see https://developer.apple.com/documentation/arkit/arreferenceimage?language=objc
- see also https://developer.apple.com/documentation/arkit/recognizing_images_in_an_ar_experience?language=objc for best practises
- `onAnchorDetected`, `onAnchorUpdated` and `onAnchorRemoved` is the more generic version of `onPlaneDetected`, etc. onAnchorDetected will notfiy about every anchor (plane and image currently).
- these callbacks passes an object with the same properties as in the `onPlane`-callbacks (position, positionAbsolute, eulerAngles, id)
- the object has a new `type`-property that specifies the type of the anchor (currently `plane` and `image`)
- depending on the type, there are additional properties on the anchor
- If you specify the `onPlane`-versions, `onAnchor` won't notify about planes atm. but i will review this decision. I am unsure whether we should have a `onXXXAnchor...` for every anchor type or just one generic `onAnchor`-callback for every anchor type (i favour the later).
- `onPlaneUpdate` has been renamed to `onPlaneUpdated` (more consistent)


## Vertical plane detection

Usage:

```
<ARKit 
  planeDetection={ARKit.ARPlaneDetection.HorizontalVertical}
/>

```

Will notify about vertical planes as well in `onPlaneDetected`. You can distinguish with `planeAnchor.alignment === ARKit.ARPlaneAnchorAlignment.Vertical` 