### PR TITLE
Allow lights to accept a color prop

### DIFF
--- a/ARKit.js
+++ b/ARKit.js
@@ -159,13 +159,12 @@ Object.keys(ARKitManager).forEach(key => {
   ARKit[key] = ARKitManager[key];
 });
 
-const addDefaultsToSnapShotFunc = funcName => ({
-  target = 'cameraRoll',
-  format = 'png'
-} = {}) => ARKitManager[funcName]({ target, format });
+const addDefaultsToSnapShotFunc = funcName => (
+  { target = 'cameraRoll', format = 'png' } = {},
+) => ARKitManager[funcName]({ target, format });
 
-ARKit.snapshot = addDefaultsToSnapShotFunc("snapshot");
-ARKit.snapshotCamera = addDefaultsToSnapShotFunc("snapshotCamera");
+ARKit.snapshot = addDefaultsToSnapShotFunc('snapshot');
+ARKit.snapshotCamera = addDefaultsToSnapShotFunc('snapshotCamera');
 
 ARKit.exportModel = presetId => {
   const id = presetId || generateId();
@@ -197,6 +196,8 @@ ARKit.propTypes = {
   onTapOnPlaneUsingExtent: PropTypes.func,
   onTapOnPlaneNoExtent: PropTypes.func,
   onEvent: PropTypes.func,
+  isMounted: PropTypes.func,
+  isInitialized: PropTypes.func,
 };
 
 const RCTARKit = requireNativeComponent('RCTARKit', ARKit);

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ These steps are mandatory regardless of doing a manual or automatic installation
 2. ARKit only runs on arm64-ready devices so the default build architecture should be set to arm64: go to `Build settings` ➜ `Build Active Architecture Only` and change the value to `Yes`.
 
 
+
+
 ## Usage
 
 A simple sample React Native ARKit App
@@ -83,6 +85,7 @@ export default class ReactNativeARKit extends Component {
           onPlaneDetected={console.log} // event listener for plane detection
           onPlaneUpdate={console.log} // event listener for plane update
           onPlaneRemoved={console.log} // arkit sometimes removes detected planes
+          onARKitError={console.log} // if arkit could not be initialized (e.g. missing permissions), you will get notified here
         >
           <ARKit.Box
             position={{ x: 0, y: 0, z: 0 }}
@@ -219,7 +222,7 @@ The `Plane` object has the following properties:
 
 ##### Static methods
 
-All methods return a promise with the result.
+All methods return a *promise* with the result.
 
 | Method Name | Arguments |  Notes
 |---|---|---|
@@ -232,7 +235,8 @@ All methods return a promise with the result.
 | `focusScene` |  | Sets the scene's position/rotation to where it was when first rendered (but now relative to your device's current position/rotation) |
 | `hitTestPlanes` | point, type  |  check if a plane has ben hit by point (`{x,y}`) with detection type (any of `ARKit.ARHitTestResultType`). See https://developer.apple.com/documentation/arkit/arhittestresulttype?language=objc for further information |
 | `hitTestSceneObjects` | point |  check if a scene object has ben hit by point (`{x,y}`) |
-
+| `isInitialized` | boolean | check whether arkit has been initialized (e.g. by mounting). See https://github.com/HippoAR/react-native-arkit/pull/152 for details |
+| `isMounted` | boolean | check whether arkit has been mounted. See https://github.com/HippoAR/react-native-arkit/pull/152 for details |
 
 #### 3D objects
 
@@ -270,16 +274,16 @@ E.g. you can scale an object on unmount:
 />
 ```
 
-#### Material properties
+#### Material
 
 Most objects take a material property with these sub-props:
 
 | Prop | Type | Description |
 |---|---|---|
-| `diffuse` | { `path`, `color`, `intensity` } | [diffuse](https://developer.apple.com/documentation/scenekit/scnmaterial/1462589-diffuse?language=objc)
-| `specular` | { `path`, `color`, `intensity` } | [specular](https://developer.apple.com/documentation/scenekit/scnmaterial/1462516-specular?language=objc)
-| `displacement` | { `path`, `color`, `intensity` } | [displacement](https://developer.apple.com/documentation/scenekit/scnmaterial/2867516-displacement?language=objc)
-| `normal` | { `path`, `color`, `intensity` } |  [normal](https://developer.apple.com/documentation/scenekit/scnmaterial/1462542-normal)
+| `diffuse` | `{ ...mapProperties }` (see below) | [diffuse](https://developer.apple.com/documentation/scenekit/scnmaterial/1462589-diffuse?language=objc)
+| `specular` | `{ ...mapProperties }` (see below) | [specular](https://developer.apple.com/documentation/scenekit/scnmaterial/1462516-specular?language=objc)
+| `displacement` | `{ ...mapProperties }` (see below) | [displacement](https://developer.apple.com/documentation/scenekit/scnmaterial/2867516-displacement?language=objc)
+| `normal` | `{ ...mapProperties }` (see below) |  [normal](https://developer.apple.com/documentation/scenekit/scnmaterial/1462542-normal)
 | `metalness` | number | metalness of the object |
 | `roughness` | number | roughness of the object |
 | `doubleSided` | boolean | render both sides, default is `true` |
@@ -290,7 +294,18 @@ Most objects take a material property with these sub-props:
 | `shaders` | Object with keys from `ARKit.ShaderModifierEntryPoint.*` and shader strings as values | [Shader modifiers](https://developer.apple.com/documentation/scenekit/scnshadable) |
 | `colorBufferWriteMask` | `ARKit.ColorMask.*` | [color mask](https://developer.apple.com/documentation/scenekit/scncolormask). Set to ARKit.ColorMask.None so that an object is transparent, but receives deferred shadows. |
 
+Map Properties:
 
+| Prop | Type | Description |
+|---|---|---|
+| `path` | string | Currently `require` is not supported, so this is an absolute link to a local resource placed for example in .xcassets |
+| `color` | string | Color string, only used if path is not provided |
+| `wrapS` | `ARKit.WrapMode.{ Clamp \| Repeat \| Mirror }` | [wrapS](https://developer.apple.com/documentation/scenekit/scnmaterialproperty/1395384-wraps?language=objc) |
+| `wrapT` | `ARKit.WrapMode.{ Clamp \| Repeat \| Mirror }` |  [wrapT](https://developer.apple.com/documentation/scenekit/scnmaterialproperty/1395382-wrapt?language=objc) |
+| `wrap` | `ARKit.WrapMode.{ Clamp \| Repeat \| Mirror }` |  Shorthand for setting both wrapS & wrapT |
+| `translation` | `{ x, y, z }` | Translate the UVs, equivalent to applying a translation matrix to SceneKit's `transformContents`  |
+| `rotation` | `{ angle, x, y, z }` | Rotate the UVs, equivalent to applying a rotation matrix to SceneKit's `transformContents` |
+| `scale` | `{ x, y, z }` | Scale the UVs, equivalent to applying a scale matrix to SceneKit's `transformContents`  |
 
 
 
@@ -537,6 +552,21 @@ E.gl you have several "walls" with ids "wall_1", "wall_2", etc.
 
 It uses https://developer.apple.com/documentation/scenekit/scnscenerenderer/1522929-hittest with some default options. Please file an issue or send a PR if you need more control over the options here!
 
+
+## FAQ:
+
+#### Which permissions does this use?
+
+- **camera access** (see section iOS Project configuration above). The user is asked for permission, as soon as you mount an `<ARKit />` component or use any of its API. If user denies access, you will get an error in `onARKitError`
+- **location service**: only needed if you use `ARKit.ARWorldAlignment.GravityAndHeading`.
+
+#### Is there an Android / ARCore version?
+
+Not yet, but there has been a proof-of-concept: https://github.com/HippoAR/react-native-arkit/issues/14. We are looking for contributors to help backporting this proof-of-conept to react-native-arkit.
+
+#### I have another question...
+
+[**Join Slack!**](https://join.slack.com/t/react-native-ar/shared_invite/enQtMjUzMzg3MjM0MTQ5LWU3Nzg2YjI4MGRjMTM1ZDBlNmIwYTE4YmM0M2U0NmY2YjBiYzQ4YzlkODExMTA0NDkwMzFhYWY4ZDE2M2Q4NGY)
 
 
 ## Contributing

--- a/components/lib/addAnimatedSupport.js
+++ b/components/lib/addAnimatedSupport.js
@@ -1,0 +1,39 @@
+import { Animated } from 'react-native';
+import React from 'react';
+import get from 'lodash/get';
+
+export default ARComponent => {
+  // there is a strange issue: animatedvalues can't be child objects,
+  // so we have to flatten them
+  // we would need to have an Animated.ValueXYZ
+  const ANIMATEABLE3D = ['position', 'eulerAngles'];
+
+  const ARComponentAnimatedInner = Animated.createAnimatedComponent(
+    class extends React.Component {
+      render() {
+        // unflatten
+        const unflattened = {};
+
+        ANIMATEABLE3D.forEach(key => {
+          unflattened[key] = {
+            x: get(this.props, `${key}_x`),
+            y: get(this.props, `${key}_y`),
+            z: get(this.props, `${key}_z`),
+          };
+        });
+        return <ARComponent {...this.props} {...unflattened} />;
+      }
+    },
+  );
+
+  return props => {
+    const flattenedProps = {};
+
+    ANIMATEABLE3D.forEach(key => {
+      flattenedProps[`${key}_x`] = get(props, [key, 'x']);
+      flattenedProps[`${key}_y`] = get(props, [key, 'y']);
+      flattenedProps[`${key}_z`] = get(props, [key, 'z']);
+    });
+    return <ARComponentAnimatedInner {...props} {...flattenedProps} />;
+  };
+};

--- a/components/lib/createArComponent.js
+++ b/components/lib/createArComponent.js
@@ -20,8 +20,9 @@ import {
   scale,
   transition,
 } from './propTypes';
-import processMaterial from './processMaterial';
+import addAnimatedSupport from './addAnimatedSupport';
 import generateId from './generateId';
+import processMaterial from './processMaterial';
 
 const { ARGeosManager } = NativeModules;
 
@@ -74,6 +75,7 @@ export default (mountConfig, propTypes = {}, nonUpdateablePropKeys = []) => {
     ...(props.shadowColor
       ? { shadowColor: processColor(props.shadowColor) }
       : {}),
+    ...(props.color ? { color: processColor(props.color) } : {}),
     ...(props.material ? { material: processMaterial(props.material) } : {}),
   });
 
@@ -227,8 +229,8 @@ export default (mountConfig, propTypes = {}, nonUpdateablePropKeys = []) => {
       return null;
     }
   };
+  const ARComponentAnimated = addAnimatedSupport(ARComponent);
+  ARComponentAnimated.propTypes = allPropTypes;
 
-  ARComponent.propTypes = allPropTypes;
-
-  return ARComponent;
+  return ARComponentAnimated;
 };

--- a/components/lib/propTypes.js
+++ b/components/lib/propTypes.js
@@ -4,35 +4,58 @@ import PropTypes from 'prop-types';
 
 const ARKitManager = NativeModules.ARKitManager;
 
+const animatableNumber = PropTypes.oneOfType([
+  PropTypes.number,
+  PropTypes.object,
+]);
 export const position = PropTypes.shape({
-  x: PropTypes.number,
-  y: PropTypes.number,
-  z: PropTypes.number,
+  x: animatableNumber,
+  y: animatableNumber,
+  z: animatableNumber,
 });
 
-export const scale = PropTypes.number;
+export const scale = animatableNumber;
 export const categoryBitMask = PropTypes.number;
 export const transition = PropTypes.shape({
   duration: PropTypes.number,
 });
 export const eulerAngles = PropTypes.shape({
-  x: PropTypes.number,
-  y: PropTypes.number,
-  z: PropTypes.number,
+  x: animatableNumber,
+  y: animatableNumber,
+  z: animatableNumber,
 });
 
 export const rotation = PropTypes.shape({
-  x: PropTypes.number,
-  y: PropTypes.number,
-  z: PropTypes.number,
-  w: PropTypes.number,
+  x: animatableNumber,
+  y: animatableNumber,
+  z: animatableNumber,
+  w: animatableNumber,
 });
 
 export const orientation = PropTypes.shape({
+  x: animatableNumber,
+  y: animatableNumber,
+  z: animatableNumber,
+  w: animatableNumber,
+});
+
+export const textureTranslation = PropTypes.shape({
   x: PropTypes.number,
   y: PropTypes.number,
   z: PropTypes.number,
-  w: PropTypes.number,
+});
+
+export const textureRotation = PropTypes.shape({
+  angle: PropTypes.number,
+  x: PropTypes.number,
+  y: PropTypes.number,
+  z: PropTypes.number,
+});
+
+export const textureScale = PropTypes.shape({
+  x: PropTypes.number,
+  y: PropTypes.number,
+  z: PropTypes.number,
 });
 
 export const shaders = PropTypes.shape({
@@ -59,12 +82,20 @@ export const colorBufferWriteMask = PropTypes.oneOf(
   values(ARKitManager.ColorMask),
 );
 
-export const opacity = PropTypes.number;
+export const opacity = animatableNumber;
+
+export const wrapMode = PropTypes.oneOf(values(ARKitManager.WrapMode));
 
 export const materialProperty = PropTypes.shape({
   path: PropTypes.string,
   color: PropTypes.string,
   intensity: PropTypes.number,
+  wrapS: wrapMode,
+  wrapT: wrapMode,
+  wrap: wrapMode,
+  translation: textureTranslation,
+  scale: textureScale,
+  rotation: textureRotation,
 });
 
 export const material = PropTypes.shape({

--- a/ios/RCTARKit.h
+++ b/ios/RCTARKit.h
@@ -21,6 +21,7 @@ typedef void (^RCTARKitReject)(NSString *code, NSString *message, NSError *error
 @interface RCTARKit : UIView
 
 + (instancetype)sharedInstance;
++ (bool)isInitialized;
 - (instancetype)initWithARView:(ARSCNView *)arView;
 
 
@@ -72,8 +73,7 @@ typedef void (^RCTARKitReject)(NSString *code, NSString *message, NSError *error
 - (NSDictionary *)readCamera;
 - (NSDictionary* )getCurrentLightEstimation;
 - (NSArray * )getCurrentDetectedFeaturePoints;
-
-
+- (bool)isMounted;
 
 #pragma mark - Delegates
 - (void)renderer:(id <SCNSceneRenderer>)renderer didRenderScene:(SCNScene *)scene atTime:(NSTimeInterval)time;

--- a/ios/RCTARKit.m
+++ b/ios/RCTARKit.m
@@ -36,9 +36,14 @@ void dispatch_once_on_main_thread(dispatch_once_t *predicate,
 
 
 @implementation RCTARKit
+static RCTARKit *instance = nil;
+
++ (bool)isInitialized {
+    return instance !=nil;
+}
 
 + (instancetype)sharedInstance {
-    static RCTARKit *instance = nil;
+    
     static dispatch_once_t onceToken;
     
     dispatch_once_on_main_thread(&onceToken, ^{
@@ -47,7 +52,13 @@ void dispatch_once_on_main_thread(dispatch_once_t *predicate,
             instance = [[self alloc] initWithARView:arView];
         }
     });
+    
     return instance;
+}
+
+- (bool)isMounted {
+    
+    return self.superview != nil;
 }
 
 - (instancetype)initWithARView:(ARSCNView *)arView {
@@ -84,6 +95,8 @@ void dispatch_once_on_main_thread(dispatch_once_t *predicate,
     }
     return self;
 }
+
+
 
 - (void)layoutSubviews {
     [super layoutSubviews];

--- a/ios/RCTARKitManager.m
+++ b/ios/RCTARKitManager.m
@@ -97,6 +97,11 @@ RCT_EXPORT_MODULE()
              @"FillMode": @{
                      @"Fill": [@(SCNFillModeFill) stringValue],
                      @"Lines": [@(SCNFillModeLines) stringValue],
+                     },
+             @"WrapMode": @{
+                     @"Clamp": [@(SCNWrapModeClamp) stringValue],
+                     @"Repeat": [@(SCNWrapModeRepeat) stringValue],
+                     @"Mirror": [@(SCNWrapModeMirror) stringValue],
                      }
              };
 }
@@ -134,6 +139,19 @@ RCT_EXPORT_METHOD(reset:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseReject
     resolve(@{});
 }
 
+RCT_EXPORT_METHOD(isInitialized:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {
+   resolve(@([ARKit isInitialized]));
+}
+
+RCT_EXPORT_METHOD(isMounted:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {
+    if( [ARKit isInitialized]) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            resolve(@([[ARKit sharedInstance] isMounted]));
+        });
+    } else {
+        resolve(@(NO));
+    }
+}
 
 RCT_EXPORT_METHOD(
                   hitTestPlanes: (NSDictionary *)pointDict

--- a/ios/RCTConvert+ARKit.m
+++ b/ios/RCTConvert+ARKit.m
@@ -306,8 +306,52 @@
 
 
 + (void)setMaterialPropertyContents:(id)property material:(SCNMaterialProperty *)material {
+    
     if (property[@"path"]) {
+        SCNMatrix4 m = SCNMatrix4Identity;
         material.contents = property[@"path"];
+        
+        if (property[@"wrapS"]) {
+            material.wrapS = (SCNWrapMode) [property[@"wrapS"] integerValue];
+        }
+        
+        if (property[@"wrapT"]) {
+            material.wrapT = (SCNWrapMode) [property[@"wrapT"] integerValue];
+        }
+        
+        if (property[@"wrap"]) {
+            material.wrapT = (SCNWrapMode) [property[@"wrapT"] integerValue];
+            material.wrapS = (SCNWrapMode) [property[@"wrapS"] integerValue];
+        }
+        
+        if (property[@"translation"]) {
+            float x = [property[@"translation"][@"x"] floatValue];
+            float y = [property[@"translation"][@"y"] floatValue];
+            float z = [property[@"translation"][@"z"] floatValue];
+            
+            m = SCNMatrix4Mult(m, SCNMatrix4MakeTranslation(x, y, z));
+        }
+        
+        if (property[@"rotation"]) {
+            float a = [property[@"rotation"][@"angle"] floatValue];
+            float x = [property[@"rotation"][@"x"] floatValue];
+            float y = [property[@"rotation"][@"y"] floatValue];
+            float z = [property[@"rotation"][@"z"] floatValue];
+            
+            m = SCNMatrix4Mult(m, SCNMatrix4MakeRotation(a, x, y, z));
+        }
+        
+        if (property[@"scale"]) {
+            float x = [property[@"scale"][@"x"] floatValue];
+            float y = [property[@"scale"][@"y"] floatValue];
+            float z = [property[@"scale"][@"z"] floatValue];
+            
+            m = SCNMatrix4Mult(m, SCNMatrix4MakeScale(x, y, z));
+        }
+        
+        material.contentsTransform = m;
+        
+        
     } else if (property[@"color"]) {
         material.contents = [self UIColor:property[@"color"]];
     }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "https://github.com/HippoAR/react-native-arkit.git"
   },
-  "version": "0.8.0",
+  "version": "0.9.0-beta.2",
   "description": "React Native binding for iOS ARKit",
   "author": "Zehao Li <qft.gtr@gmail.com>",
   "license": "MIT",

--- a/startup.js
+++ b/startup.js
@@ -6,5 +6,10 @@ export default () => {
   // when reloading the app, the scene should be cleared.
   // on prod, this usually does not happen, but you can reload the app in develop mode
   // without clearing, this would result in inconsistency
-  ARKitManager.clearScene();
+  // do this only when arkit was already initialized
+  ARKitManager.isInitialized().then(isInitialized => {
+    if (isInitialized) {
+      ARKitManager.clearScene();
+    }
+  });
 };


### PR DESCRIPTION
Lights in SceneKit accept a `color` prop at the node level, but currently we are not processing the color. This results in an error on the objc side because SceneKit tries to set the color property as an NSString.