### PR TITLE
Camera facing constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,8 @@ Most 3d object have these common properties
 | `transition` | `{duration: 1}` | Some property changes can be animated like in css transitions. Currently you can specify the duration (in seconds). |
 | `renderingOrder` | Number | Order in which object is rendered. Usefull to place elements "behind" others, although they are nearer. |
 | `categoryBitMask` | Number / bitmask | control which lights affect this object |
-| `castsShadow` | `boolean` | whether this object casts hadows |
+| `castsShadow` | `boolean` | whether this object casts shadows |
+| `constraint` | `ARKit.Constraint.{ BillboardAxisAll \| BillboardAxisX \| BillboardAxisY \| BillboardAxisZ \| None }` | Constrains the node to always point to the camera |
 
 *New experimental feature:*
 

--- a/components/lib/createArComponent.js
+++ b/components/lib/createArComponent.js
@@ -18,6 +18,7 @@ import {
   renderingOrder,
   rotation,
   scale,
+  constraint,
   transition,
 } from './propTypes';
 import addAnimatedSupport from './addAnimatedSupport';
@@ -45,6 +46,7 @@ const PROP_TYPES_NODE = {
   castsShadow,
   renderingOrder,
   opacity,
+  constraint,
 };
 
 const NODE_PROPS = keys(PROP_TYPES_NODE);

--- a/components/lib/propTypes.js
+++ b/components/lib/propTypes.js
@@ -84,6 +84,8 @@ export const colorBufferWriteMask = PropTypes.oneOf(
 
 export const opacity = animatableNumber;
 
+export const constraint = PropTypes.oneOf(values(ARKitManager.Constraint));
+
 export const wrapMode = PropTypes.oneOf(values(ARKitManager.WrapMode));
 
 export const materialProperty = PropTypes.shape({

--- a/ios/RCTARKitManager.m
+++ b/ios/RCTARKitManager.m
@@ -102,6 +102,13 @@ RCT_EXPORT_MODULE()
                      @"Clamp": [@(SCNWrapModeClamp) stringValue],
                      @"Repeat": [@(SCNWrapModeRepeat) stringValue],
                      @"Mirror": [@(SCNWrapModeMirror) stringValue],
+                     },
+             @"Constraint": @{
+                     @"None": @"0",
+                     @"BillboardAxisAll": [@(SCNBillboardAxisAll) stringValue],
+                     @"BillboardAxisX": [@(SCNBillboardAxisX) stringValue],
+                     @"BillboardAxisY": [@(SCNBillboardAxisY) stringValue],
+                     @"BillboardAxisZ": [@(SCNBillboardAxisZ) stringValue],
                      }
              };
 }

--- a/ios/RCTConvert+ARKit.m
+++ b/ios/RCTConvert+ARKit.m
@@ -441,6 +441,11 @@
     if (json[@"castsShadow"]) {
         node.castsShadow = [json[@"castsShadow"] boolValue];
     }
+    if (json[@"constraint"]) {
+        SCNBillboardConstraint *constraint = [SCNBillboardConstraint billboardConstraint];
+        constraint.freeAxes = [json[@"constraint"] integerValue];
+        node.constraints = @[constraint];
+    }
     if(json[@"transition"]) {
         NSDictionary * transition =json[@"transition"];
         if(transition[@"duration"]) {


### PR DESCRIPTION
Adds support for billboard constraints, so that one or all axes of a node will always be pointed at the camera like this: https://gfycat.com/IgnorantGrouchyElephantseal 

The SceneKit constraints system seems powerful so we could add more constraints in the future.