### PR TITLE
Add orbit camera when in running simulator 

### DIFF
--- a/ios/RCTARKit.m
+++ b/ios/RCTARKit.m
@@ -84,11 +84,11 @@ static RCTARKit *instance = nil;
         
         // configuration(s)
         arView.autoenablesDefaultLighting = YES;
-        arView.allowsCameraControl = YES;
         arView.scene.rootNode.name = @"root";
         
         #if TARGET_IPHONE_SIMULATOR
         // allow for basic orbit gestures if we're running in the simulator
+        arView.allowsCameraControl = YES;
         arView.defaultCameraController.interactionMode = SCNInteractionModeOrbitTurntable;
         arView.defaultCameraController.maximumVerticalAngle = 45;
         arView.defaultCameraController.inertiaEnabled = YES;

--- a/ios/RCTARKit.m
+++ b/ios/RCTARKit.m
@@ -84,10 +84,17 @@ static RCTARKit *instance = nil;
         
         // configuration(s)
         arView.autoenablesDefaultLighting = YES;
-        
+        arView.allowsCameraControl = YES;
         arView.scene.rootNode.name = @"root";
         
-    
+        #if TARGET_IPHONE_SIMULATOR
+        // allow for basic orbit gestures if we're running in the simulator
+        arView.defaultCameraController.interactionMode = SCNInteractionModeOrbitTurntable;
+        arView.defaultCameraController.maximumVerticalAngle = 45;
+        arView.defaultCameraController.inertiaEnabled = YES;
+        [arView.defaultCameraController translateInCameraSpaceByX:(float) 0.0 Y:(float) 0.0 Z:(float) 3.0];
+        
+        #endif
         
         // start ARKit
         [self addSubview:arView];


### PR DESCRIPTION
This PR adds support so the simulator can be used to debug the 3d scene. 
In the future we could pass in a debug config object instead of hardcoding some of the camera values.