### PR TITLE
allow all nodes to have children

### DIFF
--- a/ARKit.js
+++ b/ARKit.js
@@ -96,8 +96,11 @@ class ARKit extends Component {
           {...this.getCallbackProps()}
           // fallback to old prop type (Was boolean, now is enum)
           planeDetection={
+            /* eslint no-nested-ternary: 0 */
             isBoolean(this.props.planeDetection)
-              ? ARKit.ARPlaneDetection.Horizontal
+              ? this.props.planeDetection
+                ? ARKitManager.ARPlaneDetection.Horizontal
+                : ARKitManager.ARPlaneDetection.None
               : this.props.planeDetection
           }
           onEvent={this._onEvent}

--- a/README.md
+++ b/README.md
@@ -317,6 +317,40 @@ All methods return a *promise* with the result.
 
 ### 3D-Components
 
+This project allows you to work with 3d elements like with usual react-components.
+We provide some primitive shapes like cubes, spheres, etc. as well as
+a component to load model-files.
+
+You can also nest components to create new Components. Child-elements will
+be relative to the parent:
+
+```
+const BigExclamationMark = ({ position, eulerAngles, color = '#ff0000' }) => (
+  <ARKit.Group opacity={0.5} position={position} eulerAngles={eulerAngles}>
+    <ARKit.Sphere
+      position={{ x: 0, y: 0, z: 0 }}
+      shape={{ radius: 0.06 }}
+      material={{ diffuse: color }}
+    />
+    <ARKit.Cone
+      position={{ x: 0, y: 0.4, z: 0 }}
+      shape={{ topR: 0.1, bottomR: 0.05, height: 0.5 }}
+      material={{ diffuse: color }}
+    />
+  </ARKit.Group>
+)
+
+// somewhere else
+
+<BigExclamationMark
+  eulerAngles={{ x: 0.2 }}
+  position={{ x: 0.2, y: 0.3, z: -0.2 }}
+  color="#00ff00"
+/>
+
+```
+
+
 #### General props
 
 Most 3d object have these common properties
@@ -326,11 +360,17 @@ Most 3d object have these common properties
 | `position` | `{ x, y, z }` | The object's position (y is up) |
 | `scale` | Number | The scale of the object. Defaults to 1 |
 | `eulerAngles` | `{ x, y, z }` | The rotation in eulerAngles |
-| `rotation` | TODO | see scenkit documentation |
-| `orientation` | TODO | see scenkit documentation |
+| `id` | String | a unique identifier. Only provide one, if you need to find the node later in hit-testing. |
 | `shape` | depends on object | the shape of the object (will probably renamed to geometry in future versions)
 | `material` | `{ diffuse, metalness, roughness, lightingModel, shaders }` | the material of the object |
 | `transition` | `{duration: 1}` | Some property changes can be animated like in css transitions. Currently you can specify the duration (in seconds). |
+
+Advanced properties:
+
+| Prop | Type | Description |
+|---|---|---|
+| `rotation` | TODO | see scenkit documentation |
+| `orientation` | TODO | see scenkit documentation |
 | `renderingOrder` | Number | Order in which object is rendered. Usefull to place elements "behind" others, although they are nearer. |
 | `categoryBitMask` | Number / bitmask | control which lights affect this object |
 | `castsShadow` | `boolean` | whether this object casts shadows |
@@ -384,6 +424,13 @@ Map Properties:
 | `translation` | `{ x, y, z }` | Translate the UVs, equivalent to applying a translation matrix to SceneKit's `transformContents`  |
 | `rotation` | `{ angle, x, y, z }` | Rotate the UVs, equivalent to applying a rotation matrix to SceneKit's `transformContents` |
 | `scale` | `{ x, y, z }` | Scale the UVs, equivalent to applying a scale matrix to SceneKit's `transformContents`  |
+
+
+#### `<ARKit.Group />`
+
+This Object has no geometry, but is simply a wrapper for other components.
+It receives all common properties like position, eulerAngles, scale, opacity, etc.
+but no shape or material.
 
 
 

--- a/components/ARGroup.js
+++ b/components/ARGroup.js
@@ -1,10 +1,12 @@
-import { View } from 'react-native';
-import React, { Component } from 'react';
+//
+//  ARBox.js
+//
+//  Created by HippoAR on 8/12/17.
+//  Copyright © 2017 HippoAR. All rights reserved.
+//
 
-const ARGroup = class extends Component {
-  render() {
-    return <View>{this.props.children}</View>;
-  }
-};
+import createArComponent from './lib/createArComponent';
 
-export default ARGroup;
+const ARBox = createArComponent('addGroup', {});
+
+export default ARBox;

--- a/components/lib/addAnimatedSupport.js
+++ b/components/lib/addAnimatedSupport.js
@@ -1,6 +1,7 @@
 import { Animated } from 'react-native';
 import React from 'react';
 import get from 'lodash/get';
+import unset from 'lodash/unset';
 
 export default ARComponent => {
   // there is a strange issue: animatedvalues can't be child objects,
@@ -9,19 +10,22 @@ export default ARComponent => {
   const ANIMATEABLE3D = ['position', 'eulerAngles'];
 
   const ARComponentAnimatedInner = Animated.createAnimatedComponent(
-    class extends React.Component {
+    class extends React.PureComponent {
       render() {
         // unflatten
         const unflattened = {};
-
+        const props = { ...this.props };
         ANIMATEABLE3D.forEach(key => {
           unflattened[key] = {
-            x: get(this.props, `${key}_x`),
-            y: get(this.props, `${key}_y`),
-            z: get(this.props, `${key}_z`),
+            x: get(props, `_flattened_${key}_x`),
+            y: get(props, `_flattened_${key}_y`),
+            z: get(props, `_flattened_${key}_z`),
           };
+          unset(props, `_flattened_${key}_x`);
+          unset(props, `_flattened_${key}_y`);
+          unset(props, `_flattened_${key}_z`);
         });
-        return <ARComponent {...this.props} {...unflattened} />;
+        return <ARComponent {...props} {...unflattened} />;
       }
     },
   );
@@ -30,10 +34,11 @@ export default ARComponent => {
     const flattenedProps = {};
 
     ANIMATEABLE3D.forEach(key => {
-      flattenedProps[`${key}_x`] = get(props, [key, 'x']);
-      flattenedProps[`${key}_y`] = get(props, [key, 'y']);
-      flattenedProps[`${key}_z`] = get(props, [key, 'z']);
+      flattenedProps[`_flattened_${key}_x`] = get(props, [key, 'x']);
+      flattenedProps[`_flattened_${key}_y`] = get(props, [key, 'y']);
+      flattenedProps[`_flattened_${key}_z`] = get(props, [key, 'z']);
     });
+
     return <ARComponentAnimatedInner {...props} {...flattenedProps} />;
   };
 };

--- a/components/lib/createArComponent.js
+++ b/components/lib/createArComponent.js
@@ -1,6 +1,6 @@
 import { NativeModules, processColor } from 'react-native';
 import PropTypes from 'prop-types';
-import React, { Component, Fragment } from 'react';
+import React, { PureComponent, Fragment } from 'react';
 import filter from 'lodash/filter';
 import isDeepEqual from 'fast-deep-equal';
 import isEmpty from 'lodash/isEmpty';
@@ -111,7 +111,7 @@ export default (mountConfig, propTypes = {}, nonUpdateablePropKeys = []) => {
     return ARGeosManager.unmount(id);
   };
 
-  const ARComponent = class extends Component {
+  const ARComponent = class extends PureComponent {
     constructor(props) {
       super(props);
       this.identifier = props.id || generateId();
@@ -146,7 +146,6 @@ export default (mountConfig, propTypes = {}, nonUpdateablePropKeys = []) => {
         keys(this.props),
         key => key !== 'children' && !isDeepEqual(props[key], this.props[key]),
       );
-      console.log('changedKeys', this.identifier, changedKeys);
       if (isEmpty(changedKeys)) {
         return;
       }
@@ -187,6 +186,7 @@ export default (mountConfig, propTypes = {}, nonUpdateablePropKeys = []) => {
         update(this.identifier, propsToupdate).catch(() => {
           // sometimes calls are out of order, so this node has been unmounted
           // we therefore mount again
+
           this.mountWithProps({ ...this.props, ...props });
         });
       }

--- a/components/lib/createArComponent.js
+++ b/components/lib/createArComponent.js
@@ -25,6 +25,8 @@ import addAnimatedSupport from './addAnimatedSupport';
 import generateId from './generateId';
 import processMaterial from './processMaterial';
 
+const DEBUG = false;
+
 const { ARGeosManager } = NativeModules;
 
 const PROP_TYPES_IMMUTABLE = {
@@ -51,7 +53,7 @@ const PROP_TYPES_NODE = {
 
 const NODE_PROPS = keys(PROP_TYPES_NODE);
 const IMMUTABLE_PROPS = keys(PROP_TYPES_IMMUTABLE);
-const DEBUG = false;
+
 const TIMERS = {};
 
 /**

--- a/components/lib/processMaterial.js
+++ b/components/lib/processMaterial.js
@@ -4,7 +4,8 @@ import { isObject, isString, mapValues, set } from 'lodash';
 // https://developer.apple.com/documentation/scenekit/scnmaterial
 const propsWithMaps = ['normal', 'diffuse', 'displacement', 'specular'];
 
-export default function processMaterial(material) {
+export default function processMaterial(materialOrg) {
+  const material = { ...materialOrg };
   // previously it was possible to set { material: { color:'colorstring'}}... translate this to { material: { diffuse: { color: 'colorstring'}}}
   if (material.color) {
     set(material, 'diffuse.color', material.color);

--- a/ios/RCTARKit.m
+++ b/ios/RCTARKit.m
@@ -481,7 +481,7 @@ static NSDictionary * getPlaneHitResult(NSMutableArray *resultsMapped, const CGP
     }
     
     if(self.onTapOnPlaneNoExtent) {
-        // Take the screen space tap coordinates and pass them to the hitTest method on the ARSCNView instance
+        // Take the screen space tap coordinates    and pass them to the hitTest method on the ARSCNView instance
         NSDictionary * planeHitResult = [self getPlaneHitResult:tapPoint types:ARHitTestResultTypeExistingPlane];
         self.onTapOnPlaneNoExtent(planeHitResult);
     }
@@ -498,6 +498,8 @@ static NSDictionary * getPlaneHitResult(NSMutableArray *resultsMapped, const CGP
         }
     }
 }
+
+
 
 - (void)renderer:(id <SCNSceneRenderer>)renderer didRenderScene:(SCNScene *)scene atTime:(NSTimeInterval)time {
     for (id<RCTARKitRendererDelegate> rendererDelegate in self.rendererDelegates) {

--- a/ios/RCTARKitNodes.h
+++ b/ios/RCTARKitNodes.h
@@ -35,12 +35,12 @@ typedef NS_OPTIONS(NSUInteger, RFReferenceFrame) {
 
 + (instancetype)sharedInstance;
 
-- (void)addNodeToScene:(SCNNode *)node inReferenceFrame:(NSString *)referenceFrame;
+- (void)addNodeToScene:(SCNNode *)node inReferenceFrame:(NSString *)referenceFrame withParentId:(NSString *)parentId;
 - (bool)updateNode:(NSString *)nodeId properties:(NSDictionary *) properties;
 - (float)getCameraDistanceToPoint:(SCNVector3)point;
-- (void)registerNode:(SCNNode *)node forKey:(NSString *)key;
-- (SCNNode *)nodeForKey:(NSString *)key;
-- (void)removeNodeForKey:(NSString *)key;
+- (void)registerNode:(SCNNode *)node withId:(NSString *)key;
+- (SCNNode *)getNodeWithId:(NSString *)key;
+- (void)removeNode:(NSString *)key;
 - (NSDictionary *)getSceneObjectsHitResult:(const CGPoint)tapPoint;
 - (void)clear;
 - (NSMutableArray *) mapHitResults:(NSArray<ARHitTestResult *> *)results;

--- a/ios/components/ARGeosManager.m
+++ b/ios/components/ARGeosManager.m
@@ -13,66 +13,71 @@
 
 RCT_EXPORT_MODULE()
 
-RCT_EXPORT_METHOD(addBox:(SCNBox *)geometry node:(SCNNode *)node frame:(NSString *)frame) {
+RCT_EXPORT_METHOD(addBox:(SCNBox *)geometry node:(SCNNode *)node frame:(NSString *)frame parentId:(NSString *)parentId) {
     node.geometry = geometry;
-    [[RCTARKitNodes sharedInstance] addNodeToScene:node inReferenceFrame:frame];
+    [[RCTARKitNodes sharedInstance] addNodeToScene:node inReferenceFrame:frame withParentId:parentId];
+}
+
+RCT_EXPORT_METHOD(addGroup:(id)bla node:(SCNNode *)node frame:(NSString *)frame parentId:(NSString *)parentId) {
+    
+    [[RCTARKitNodes sharedInstance] addNodeToScene:node inReferenceFrame:frame withParentId:parentId];
 }
 
 
-RCT_EXPORT_METHOD(addSphere:(SCNSphere *)geometry node:(SCNNode *)node frame:(NSString *)frame) {
+RCT_EXPORT_METHOD(addSphere:(SCNSphere *)geometry node:(SCNNode *)node frame:(NSString *)frame parentId:(NSString *)parentId) {
     node.geometry = geometry;
-    [[RCTARKitNodes sharedInstance] addNodeToScene:node inReferenceFrame:frame];
+    [[RCTARKitNodes sharedInstance] addNodeToScene:node inReferenceFrame:frame withParentId:parentId];
 }
 
-RCT_EXPORT_METHOD(addCylinder:(SCNCylinder *)geometry node:(SCNNode *)node frame:(NSString *)frame) {
+RCT_EXPORT_METHOD(addCylinder:(SCNCylinder *)geometry node:(SCNNode *)node frame:(NSString *)frame parentId:(NSString *)parentId) {
     node.geometry = geometry;
-    [[RCTARKitNodes sharedInstance] addNodeToScene:node inReferenceFrame:frame];
+    [[RCTARKitNodes sharedInstance] addNodeToScene:node inReferenceFrame:frame withParentId:parentId];
 }
 
-RCT_EXPORT_METHOD(addCone:(SCNCone *)geometry node:(SCNNode *)node frame:(NSString *)frame) {
+RCT_EXPORT_METHOD(addCone:(SCNCone *)geometry node:(SCNNode *)node frame:(NSString *)frame parentId:(NSString *)parentId) {
     node.geometry = geometry;
-    [[RCTARKitNodes sharedInstance] addNodeToScene:node inReferenceFrame:frame];
+    [[RCTARKitNodes sharedInstance] addNodeToScene:node inReferenceFrame:frame withParentId:parentId];
 }
 
-RCT_EXPORT_METHOD(addPyramid:(SCNPyramid *)geometry node:(SCNNode *)node frame:(NSString *)frame) {
+RCT_EXPORT_METHOD(addPyramid:(SCNPyramid *)geometry node:(SCNNode *)node frame:(NSString *)frame parentId:(NSString *)parentId) {
     node.geometry = geometry;
-    [[RCTARKitNodes sharedInstance] addNodeToScene:node inReferenceFrame:frame];
+    [[RCTARKitNodes sharedInstance] addNodeToScene:node inReferenceFrame:frame withParentId:parentId];
 }
 
-RCT_EXPORT_METHOD(addTube:(SCNTube *)geometry node:(SCNNode *)node frame:(NSString *)frame) {
+RCT_EXPORT_METHOD(addTube:(SCNTube *)geometry node:(SCNNode *)node frame:(NSString *)frame parentId:(NSString *)parentId) {
     node.geometry = geometry;
-    [[RCTARKitNodes sharedInstance] addNodeToScene:node inReferenceFrame:frame];
+    [[RCTARKitNodes sharedInstance] addNodeToScene:node inReferenceFrame:frame withParentId:parentId];
 }
 
-RCT_EXPORT_METHOD(addTorus:(SCNTorus *)geometry node:(SCNNode *)node frame:(NSString *)frame) {
+RCT_EXPORT_METHOD(addTorus:(SCNTorus *)geometry node:(SCNNode *)node frame:(NSString *)frame parentId:(NSString *)parentId) {
     node.geometry = geometry;
-    [[RCTARKitNodes sharedInstance] addNodeToScene:node inReferenceFrame:frame];
+    [[RCTARKitNodes sharedInstance] addNodeToScene:node inReferenceFrame:frame withParentId:parentId];
 }
 
-RCT_EXPORT_METHOD(addCapsule:(SCNCapsule *)geometry node:(SCNNode *)node frame:(NSString *)frame) {
+RCT_EXPORT_METHOD(addCapsule:(SCNCapsule *)geometry node:(SCNNode *)node frame:(NSString *)frame parentId:(NSString *)parentId) {
     node.geometry = geometry;
-    [[RCTARKitNodes sharedInstance] addNodeToScene:node inReferenceFrame:frame];
+    [[RCTARKitNodes sharedInstance] addNodeToScene:node inReferenceFrame:frame withParentId:parentId];
 }
 
-RCT_EXPORT_METHOD(addPlane:(SCNPlane *)geometry node:(SCNNode *)node frame:(NSString *)frame) {
+RCT_EXPORT_METHOD(addPlane:(SCNPlane *)geometry node:(SCNNode *)node frame:(NSString *)frame parentId:(NSString *)parentId) {
     node.geometry = geometry;
-    [[RCTARKitNodes sharedInstance] addNodeToScene:node inReferenceFrame:frame];
+    [[RCTARKitNodes sharedInstance] addNodeToScene:node inReferenceFrame:frame withParentId:parentId];
 }
 
-RCT_EXPORT_METHOD(addShape:(SCNShape *)geometry node:(SCNNode *)node frame:(NSString *)frame) {
+RCT_EXPORT_METHOD(addShape:(SCNShape *)geometry node:(SCNNode *)node frame:(NSString *)frame parentId:(NSString *)parentId) {
     node.geometry = geometry;
-    [[RCTARKitNodes sharedInstance] addNodeToScene:node inReferenceFrame:frame];
+    [[RCTARKitNodes sharedInstance] addNodeToScene:node inReferenceFrame:frame withParentId:parentId];
 }
 
-RCT_EXPORT_METHOD(addLight:(SCNLight *)light node:(SCNNode *)node frame:(NSString *)frame) {
+RCT_EXPORT_METHOD(addLight:(SCNLight *)light node:(SCNNode *)node frame:(NSString *)frame parentId:(NSString *)parentId) {
     node.light = light;
-    [[RCTARKitNodes sharedInstance] addNodeToScene:node inReferenceFrame:frame];
+    [[RCTARKitNodes sharedInstance] addNodeToScene:node inReferenceFrame:frame withParentId:parentId];
 }
 
 
 RCT_EXPORT_METHOD(unmount:(NSString *)identifier) {
     //NSLog(@"unmounting node: %@ ", identifier);
-    [[RCTARKitNodes sharedInstance] removeNodeForKey:identifier];
+    [[RCTARKitNodes sharedInstance] removeNode:identifier];
 }
 
 RCT_EXPORT_METHOD(updateNode:(NSString *)identifier properties:(NSDictionary *) properties resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {
@@ -86,3 +91,4 @@ RCT_EXPORT_METHOD(updateNode:(NSString *)identifier properties:(NSDictionary *) 
 }
 
 @end
+

--- a/ios/components/ARModelManager.m
+++ b/ios/components/ARModelManager.m
@@ -15,10 +15,10 @@
 
 RCT_EXPORT_MODULE()
 
-RCT_EXPORT_METHOD(mount:(NSDictionary *)property node:(SCNNode *)node frame:(NSString *)frame) {
+RCT_EXPORT_METHOD(mount:(NSDictionary *)property node:(SCNNode *)node frame:(NSString *)frame parentId:(NSString *)parentId) {
     //NSLog(@"mounting node: %@ ", node.name);
     // we need to mount first, otherwise, if the loading of the model is slow, it will be registered too late
-    [[RCTARKitNodes sharedInstance] addNodeToScene:node inReferenceFrame:frame];
+    [[RCTARKitNodes sharedInstance] addNodeToScene:node inReferenceFrame:frame withParentId:parentId];
     // we need to do the model loading in its own queue, otherwise it can block, so that react-to-native-calls get out of order
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         NSDictionary *model = property[@"model"];

--- a/ios/components/ARTextManager.m
+++ b/ios/components/ARTextManager.m
@@ -14,9 +14,9 @@
 
 RCT_EXPORT_MODULE()
 
-RCT_EXPORT_METHOD(mount:(SCNTextNode *)textNode node:(SCNNode *)node frame:(NSString *)frame) {
+RCT_EXPORT_METHOD(mount:(SCNTextNode *)textNode node:(SCNNode *)node frame:(NSString *)frame parentId:(NSString *)parentId) {
     [node addChildNode:textNode];
-    [[RCTARKitNodes sharedInstance] addNodeToScene:node inReferenceFrame:frame];
+    [[RCTARKitNodes sharedInstance] addNodeToScene:node inReferenceFrame:frame withParentId:parentId];
 }
 
 @end

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "https://github.com/HippoAR/react-native-arkit.git"
   },
-  "version": "0.9.0-beta.3",
+  "version": "0.9.0-beta.4",
   "description": "React Native binding for iOS ARKit",
   "author": "Zehao Li <qft.gtr@gmail.com>",
   "license": "MIT",
@@ -23,7 +23,7 @@
     "@panter/react-animation-frame": "^0.3.7",
     "fast-deep-equal": "^1.0.0",
     "lodash": "^4.17.4",
-    "prop-types": "^15.5.7"
+    "prop-types": "^15.6.0"
   },
   "devDependencies": {
     "babel-eslint": "^7.2.3",
@@ -37,7 +37,7 @@
     "eslint-plugin-prettier": "^2.1.1",
     "eslint-plugin-react": "^7.0.1",
     "prettier": "^1.3.1",
-    "react": "16.0.0-alpha.12",
-    "prop-types": "^15.5.8"
+    "react": "16.2.0",
+    "prop-types": "^15.6.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8,10 +8,6 @@
   dependencies:
     react "15.4.2"
 
-"_PocketSVG@https://github.com/pocketsvg/PocketSVG":
-  version "0.0.0"
-  resolved "https://github.com/pocketsvg/PocketSVG#e6d84ddeb11f99c4420e354ebb9fd34db2cf507a"
-
 acorn-jsx@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-3.0.1.tgz#afdf9488fb1ecefc8348f6fb22f464e32a58b36b"
@@ -584,14 +580,6 @@ core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
-create-react-class@^15.5.2:
-  version "15.6.0"
-  resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.6.0.tgz#ab448497c26566e1e29413e883207d57cfe7bed4"
-  dependencies:
-    fbjs "^0.8.9"
-    loose-envify "^1.3.1"
-    object-assign "^4.1.1"
-
 cross-spawn@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
@@ -881,7 +869,7 @@ fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
 
-fbjs@^0.8.4:
+fbjs@^0.8.16, fbjs@^0.8.4:
   version "0.8.16"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
   dependencies:
@@ -1416,12 +1404,20 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.10, prop-types@^15.5.6, prop-types@^15.5.7:
+prop-types@^15.5.10:
   version "15.5.10"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
   dependencies:
     fbjs "^0.8.9"
     loose-envify "^1.3.1"
+
+prop-types@^15.6.0:
+  version "15.6.1"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.1.tgz#36644453564255ddda391191fb3a125cbdf654ca"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
 
 pseudomap@^1.0.2:
   version "1.0.2"
@@ -1453,15 +1449,14 @@ react@15.4.2:
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
 
-react@16.0.0-alpha.12:
-  version "16.0.0-alpha.12"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.0.0-alpha.12.tgz#8c59485281485df319b6f77682d8dd0621c08194"
+react@16.2.0:
+  version "16.2.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.2.0.tgz#a31bd2dab89bff65d42134fa187f24d054c273ba"
   dependencies:
-    create-react-class "^15.5.2"
-    fbjs "^0.8.9"
+    fbjs "^0.8.16"
     loose-envify "^1.1.0"
-    object-assign "^4.1.0"
-    prop-types "^15.5.6"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
 
 read-pkg-up@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
fixes https://github.com/HippoAR/react-native-arkit/issues/109 and https://github.com/HippoAR/react-native-arkit/issues/45

Now, every AR* component can have children. Every child will be relative to its parent:

- position of children is now relative to parents
- eulerAngles and other rotations as well
- opacity
- scale

You now can create more complex Components out of smaller ones

This is still experimental and relies on ids. we have to test whether this works well if you add/remove/change childrens

Sidenote about `id`s: every id still needs to be unique across all nodes, even if they are children of others!