### PR TITLE
Improved ARSprite

### DIFF
--- a/components/ARSprite.js
+++ b/components/ARSprite.js
@@ -1,7 +1,6 @@
+import { View, NativeModules } from 'react-native';
 import React, { Component } from 'react';
 import withAnimationFrame from '@panter/react-animation-frame';
-
-import { NativeModules, Animated } from 'react-native';
 
 import { position } from './lib/propTypes';
 
@@ -11,41 +10,39 @@ const ARSprite = withAnimationFrame(
   class extends Component {
     constructor(props) {
       super(props);
-      this.state = {
-        zIndex: new Animated.Value(),
-        pos2D: new Animated.ValueXY() // inits to zero
-      };
+
+      this._pos2D = { x: 0, y: 0 };
     }
+    setNativeProps = nativeProps => {
+      this._root.setNativeProps(nativeProps);
+    };
     onAnimationFrame() {
-      ARKitManager.projectPoint(this.props.position).then(
-        Animated.event([
-          {
-            x: this.state.pos2D.x,
-            y: this.state.pos2D.y,
-            z: this.state.zIndex
-          }
-        ])
-      );
+      if (this.pos)
+        this.setNativeProps({
+          style: {
+            position: 'absolute',
+            transform: [{ translateX: this.pos.x }, { translateY: this.pos.y }],
+            ...this.props.style,
+          },
+        });
+      ARKitManager.projectPoint(this.props.position).then(pos => {
+        this.pos = pos;
+      });
     }
 
     render() {
       return (
-        <Animated.View
-          style={{
-            position: 'absolute',
-            transform: this.state.pos2D.getTranslateTransform(),
-            ...this.props.style
-          }}
-        >
+        /* eslint no-return-assign: 0 */
+        <View ref={component => (this._root = component)}>
           {this.props.children}
-        </Animated.View>
+        </View>
       );
     }
-  }
+  },
 );
 
 ARSprite.propTypes = {
-  position
+  position,
 };
 
 export default ARSprite;

--- a/ios/RCTARKit.h
+++ b/ios/RCTARKit.h
@@ -82,6 +82,8 @@ typedef void (^RCTARKitReject)(NSString *code, NSString *message, NSError *error
 - (NSDictionary* )getCurrentLightEstimation;
 - (NSArray * )getCurrentDetectedFeaturePoints;
 - (bool)isMounted;
+- (void)addRendererDelegates:(id)delegate;
+- (void)removeRendererDelegates:(id)delegate;
 
 #pragma mark - Delegates
 - (void)renderer:(id <SCNSceneRenderer>)renderer didRenderScene:(SCNScene *)scene atTime:(NSTimeInterval)time;

--- a/ios/RCTARKit.m
+++ b/ios/RCTARKit.m
@@ -104,6 +104,7 @@ static RCTARKit *instance = nil;
 
 
 
+
 - (void)layoutSubviews {
     [super layoutSubviews];
     //NSLog(@"setting view bounds %@", NSStringFromCGRect(self.bounds));
@@ -560,6 +561,16 @@ static NSDictionary * getPlaneHitResult(NSMutableArray *resultsMapped, const CGP
     
 }
   #endif
+
+- (void)addRendererDelegates:(id) delegate {
+     [self.rendererDelegates addObject:delegate];
+    NSLog(@"added, number of renderer delegates %d", [self.rendererDelegates count]);
+}
+
+- (void)removeRendererDelegates:(id) delegate {
+    [self.rendererDelegates removeObject:delegate];
+     NSLog(@"removed, number of renderer delegates %d", [self.rendererDelegates count]);
+}
 - (void)renderer:(id <SCNSceneRenderer>)renderer willUpdateNode:(SCNNode *)node forAnchor:(ARAnchor *)anchor {
 }
 

--- a/ios/RCTARKit.xcodeproj/project.pbxproj
+++ b/ios/RCTARKit.xcodeproj/project.pbxproj
@@ -16,6 +16,8 @@
 		10FEF6141F774C9000EC21AE /* RCTARKitIO.m in Sources */ = {isa = PBXBuildFile; fileRef = 10FEF6101F774C8F00EC21AE /* RCTARKitIO.m */; };
 		10FEF6151F774C9000EC21AE /* RCTARKitNodes.m in Sources */ = {isa = PBXBuildFile; fileRef = 10FEF6121F774C9000EC21AE /* RCTARKitNodes.m */; };
 		B1990B221FCEEBD60001AE2F /* color-grabber.m in Sources */ = {isa = PBXBuildFile; fileRef = B1990B211FCEEBD60001AE2F /* color-grabber.m */; };
+		B1CEA29F204C14090025C1B8 /* RCTARKitSpriteView.m in Sources */ = {isa = PBXBuildFile; fileRef = B1CEA29E204C14090025C1B8 /* RCTARKitSpriteView.m */; };
+		B1CEA2A3204C160D0025C1B8 /* RCTARKitSpriteViewManager.m in Sources */ = {isa = PBXBuildFile; fileRef = B1CEA2A2204C160D0025C1B8 /* RCTARKitSpriteViewManager.m */; };
 		B3E7B58A1CC2AC0600A0062D /* RCTARKit.m in Sources */ = {isa = PBXBuildFile; fileRef = B3E7B5891CC2AC0600A0062D /* RCTARKit.m */; };
 /* End PBXBuildFile section */
 
@@ -63,6 +65,10 @@
 		B14C36651F960C6E0047CB67 /* PocketSVG.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PocketSVG.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B1990B201FCEEBD60001AE2F /* color-grabber.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "color-grabber.h"; sourceTree = "<group>"; };
 		B1990B211FCEEBD60001AE2F /* color-grabber.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "color-grabber.m"; sourceTree = "<group>"; };
+		B1CEA29E204C14090025C1B8 /* RCTARKitSpriteView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RCTARKitSpriteView.m; sourceTree = "<group>"; };
+		B1CEA2A0204C15500025C1B8 /* RCTARKitSpriteView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RCTARKitSpriteView.h; sourceTree = "<group>"; };
+		B1CEA2A1204C15FE0025C1B8 /* RCTARKitSpriteViewManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RCTARKitSpriteViewManager.h; sourceTree = "<group>"; };
+		B1CEA2A2204C160D0025C1B8 /* RCTARKitSpriteViewManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RCTARKitSpriteViewManager.m; sourceTree = "<group>"; };
 		B3E7B5881CC2AC0600A0062D /* RCTARKit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTARKit.h; sourceTree = "<group>"; };
 		B3E7B5891CC2AC0600A0062D /* RCTARKit.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTARKit.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -81,6 +87,10 @@
 		106999E21F3EC2FB00032829 /* components */ = {
 			isa = PBXGroup;
 			children = (
+				B1CEA2A2204C160D0025C1B8 /* RCTARKitSpriteViewManager.m */,
+				B1CEA2A1204C15FE0025C1B8 /* RCTARKitSpriteViewManager.h */,
+				B1CEA2A0204C15500025C1B8 /* RCTARKitSpriteView.h */,
+				B1CEA29E204C14090025C1B8 /* RCTARKitSpriteView.m */,
 				10DCBC491F7CE836008C89E7 /* ARGeosManager.h */,
 				10DCBC4A1F7CE836008C89E7 /* ARGeosManager.m */,
 				1021FE1A1F3EDB90000E7339 /* ARTextManager.h */,
@@ -206,6 +216,8 @@
 				105F124E1F7C0719006D4BA3 /* RCTConvert+ARKit.m in Sources */,
 				B3E7B58A1CC2AC0600A0062D /* RCTARKit.m in Sources */,
 				10062C831F127572009AE974 /* RCTARKitManager.m in Sources */,
+				B1CEA29F204C14090025C1B8 /* RCTARKitSpriteView.m in Sources */,
+				B1CEA2A3204C160D0025C1B8 /* RCTARKitSpriteViewManager.m in Sources */,
 				10ED47A71F38BC01004DF043 /* DeviceMotion.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ios/RCTARKitDelegate.h
+++ b/ios/RCTARKitDelegate.h
@@ -7,6 +7,8 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <SceneKit/SceneKit.h>
+#import <ARKit/ARKit.h>
 
 @protocol RCTARKitTouchDelegate <NSObject>
 @optional

--- a/ios/RCTARKitNodes.m
+++ b/ios/RCTARKitNodes.m
@@ -292,14 +292,14 @@ static id ObjectOrNull(id object)
 - (void)registerNode:(SCNNode *)node withId:(NSString *)nodeId {
     [self removeNode:nodeId];
     if (node) {
-        NSLog(@"registering node %@", nodeId);
+        //NSLog(@"registering node %@", nodeId);
         [self.nodes setObject:node forKey:nodeId];
         
-        // are there any orphans?
+        // are there any orphans? (3d objects that have a parent, but parent has not yet been mounted
+        // this seems to be the default case as react mounts first the children
         NSSet * orphans = [self.orphans objectForKey:nodeId];
         if(orphans) {
             for (SCNNode * child in [orphans allObjects]) {
-                
                 [node addChildNode:child];
             }
             [self.orphans removeObjectForKey:nodeId];

--- a/ios/components/RCTARKitSpriteView.h
+++ b/ios/components/RCTARKitSpriteView.h
@@ -1,0 +1,22 @@
+//
+//  RCTARKitSpriteView.h
+//  RCTARKit
+//
+//  Created by Marco Wettstein on 04.03.18.
+//  Copyright © 2018 HippoAR. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+#import "RCTARKit.h"
+#import <React/RCTView.h>
+#import "RCTARKitDelegate.h"
+
+@interface RCTARKitSpriteView : RCTView <RCTARKitRendererDelegate>
+
+@property (nonatomic, assign) SCNVector3 position3D;
+@property (nonatomic, assign) float transitionDuration;
+
+@end
+
+
+

--- a/ios/components/RCTARKitSpriteView.m
+++ b/ios/components/RCTARKitSpriteView.m
@@ -1,0 +1,49 @@
+//
+//  RCTARKitSpriteView.m
+//  RCTARKit
+//
+//  Created by Marco Wettstein on 04.03.18.
+//  Copyright © 2018 HippoAR. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+
+#import "RCTARKitSpriteView.h"
+#import "RCTConvert+ARKit.h"
+#import <UIKit/UIKit.h>
+#import <QuartzCore/QuartzCore.h>
+
+@implementation RCTARKitSpriteView {
+
+}
+
+
+
+- (CGAffineTransform)getTransform {
+    SCNVector3 point = [[ARKit sharedInstance] projectPoint:self.position3D];
+    CGAffineTransform t = CGAffineTransformMakeTranslation(point.x, point.y);
+    return t;
+}
+
+- (void)didMoveToSuperview {
+    // set it once
+    CGAffineTransform t = [self getTransform];
+    [self setTransform:t];
+}
+
+- (void)renderer:(id<SCNSceneRenderer>)renderer updateAtTime:(NSTimeInterval)time {
+    [self performSelectorOnMainThread:@selector(setTransformByProject) withObject:nil waitUntilDone:NO];
+    
+}
+
+- (void)setTransformByProject {
+    CGAffineTransform t = [self getTransform];
+    [UIView beginAnimations:nil context:NULL];
+    
+    [UIView setAnimationDuration:self.transitionDuration];
+    [self setTransform:t];
+    [UIView commitAnimations];
+}
+
+@end

--- a/ios/components/RCTARKitSpriteViewManager.h
+++ b/ios/components/RCTARKitSpriteViewManager.h
@@ -1,0 +1,5 @@
+#import <React/RCTViewManager.h>
+
+@interface RCTARKitSpriteViewManager : RCTViewManager
+
+@end

--- a/ios/components/RCTARKitSpriteViewManager.m
+++ b/ios/components/RCTARKitSpriteViewManager.m
@@ -1,0 +1,46 @@
+#import "RCTARKitSpriteViewManager.h"
+#import "RCTARKitSpriteView.h"
+#import <React/RCTUIManager.h>
+#import <React/RCTBridgeModule.h>
+#import "RCTARKit.h"
+
+@implementation RCTARKitSpriteViewManager
+
+RCT_EXPORT_MODULE();
+
+@synthesize bridge = _bridge;
+
+RCT_EXPORT_VIEW_PROPERTY(position3D, SCNVector3)
+RCT_EXPORT_VIEW_PROPERTY(transitionDuration, float)
+
+- (UIView *)view
+{
+    UIView * view =  [[RCTARKitSpriteView alloc] init];
+    
+    return view;
+}
+
+
+RCT_EXPORT_METHOD(startAnimation:(nonnull NSNumber *)reactTag)
+{
+    [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTARKitSpriteView *> *viewRegistry) {
+        RCTARKitSpriteView *view = viewRegistry[reactTag];
+        if ([view isKindOfClass:[RCTARKitSpriteView class]]) {
+              [[ARKit sharedInstance] addRendererDelegates:view];
+        }
+    }];
+}
+
+RCT_EXPORT_METHOD(stopAnimation:(nonnull NSNumber *)reactTag)
+{
+    [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTARKitSpriteView *> *viewRegistry) {
+        RCTARKitSpriteView *view = viewRegistry[reactTag];
+        if ([view isKindOfClass:[RCTARKitSpriteView class]]) {
+            [[ARKit sharedInstance] removeRendererDelegates:view];
+        }
+    }];
+}
+
+
+
+@end


### PR DESCRIPTION
This change improves the `<ARSprite />` component which was a bit laggy before. It uses now a native loop to render its position, rather then serializing back and forth between js code and native code.

`<ARSprite />` can render ordinary react views on the scene:

```
<ARKit.Sprite
        position={{x: 0, y: 0, z:0}}
        // you can now also give it transition duration
        // this makes the sprite more "smooth". We default it to 0.05s which gives good results
        transition={{
          duration: 0.05
        }}
      >
        <Text>This is the origin</Text>
      </ARKit.Sprite>
```